### PR TITLE
Do not override default Travis commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,5 @@ jdk:
   - oraclejdk8
   - openjdk7
 
-env:
-  - BUILD=build
-
 matrix:
   fast_finish: true
-
-install:
-  - if [[ $BUILD == 'build' ]]; then mvn install; fi


### PR DESCRIPTION
From https://docs.travis-ci.com/user/languages/java/#Projects-Using-Maven, the default Travis environment firsts calls `mvn install` skipping tests and Javadoc then `mvn test`.

Overriding `mvn install` is unnecessary and causes the tests to be executed twice. This commit should increase the build time.