### PR TITLE
Bump to the next development cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # OME Common Java
 
 [![Build Status](https://travis-ci.org/ome/ome-common-java.png)](http://travis-ci.org/ome/ome-common-java)
+[![Maven Central](https://img.shields.io/maven-central/v/org.openmicroscopy/ome-common.svg)](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.openmicroscopy%22%20AND%20a%3A%22ome-common%22)
+[![Javadocs](http://javadoc.io/badge/org.openmicroscopy/ome-common.svg)](http://javadoc.io/doc/org.openmicroscopy/ome-common)
 
 Common I/O, date parsing, and XML processing classes for OME Java components.
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.openmicroscopy</groupId>
   <artifactId>ome-common</artifactId>
-  <version>5.3.0</version>
+  <version>5.3.1-SNAPSHOT</version>
 
   <name>OME Common Java</name>
   <description>Contains common I/O, date parsing, and XML processing classes.</description>


### PR DESCRIPTION
- bump the version number to 5.3.1-SNAPSHOT
- also add badge for Maven Central and Javadoc