### PR TITLE
Cleanup references to OME artifactory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -427,54 +427,12 @@
     <url>http://github.com/ome/ome-common-java</url>
   </scm>
 
-  <repositories>
-    <repository>
-        <id>ome.experimental</id>
-        <url>http://artifacts.openmicroscopy.org/artifactory/ome.experimental</url>
-    </repository>
-    <repository>
-      <id>ome.external</id>
-      <url>http://artifacts.openmicroscopy.org/artifactory/ome.external</url>
-    </repository>
-    <repository>
-      <id>ome.releases</id>
-      <url>http://artifacts.openmicroscopy.org/artifactory/ome.releases</url>
-    </repository>
-    <repository>
-      <id>ome.snapshots</id>
-      <url>http://artifacts.openmicroscopy.org/artifactory/ome.snapshots</url>
-    </repository>
-    <repository>
-      <id>unidata.releases</id>
-      <url>http://artifacts.unidata.ucar.edu/content/repositories/unidata-releases</url>
-    </repository>
-  </repositories>
-
   <pluginRepositories>
     <pluginRepository>
       <id>central</id>
       <name>Central Repository</name>
       <url>http://repo.maven.apache.org/maven2</url>
       <layout>default</layout>
-    </pluginRepository>
-    <pluginRepository>
-      <id>ome.releases</id>
-      <url>http://artifacts.openmicroscopy.org/artifactory/ome.releases</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>ome.snapshots</id>
-      <url>http://artifacts.openmicroscopy.org/artifactory/ome.snapshots</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
-    <pluginRepository>
-      <id>ome.external</id>
-      <url>http://artifacts.openmicroscopy.org/artifactory/ome.external</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>ome.experimental</id>
-      <url>http://artifacts.openmicroscopy.org/artifactory/ome.experimental</url>
     </pluginRepository>
   </pluginRepositories>
 


### PR DESCRIPTION
These lines came from the original branch filtering but are now unnecessary as this repository should exclusively depend on dependencies hosted in Maven Central.

To test this PR check that Travis remains green. I purged the  cache before opening the PR so dependencies should be downloaded.