### PR TITLE
Register JPEG-XR service

### DIFF
--- a/src/main/java/loci/common/services/services.properties
+++ b/src/main/java/loci/common/services/services.properties
@@ -57,3 +57,4 @@ loci.formats.services.JPEGTurboService=loci.formats.services.JPEGTurboServiceImp
 # Woolz service (interface and implementation in bio-formats)
 loci.formats.services.WlzService=loci.formats.services.WlzServiceImpl
 loci.formats.services.EXIFService=loci.formats.services.EXIFServiceImpl
+loci.formats.services.JPEGXRService=loci.formats.services.JPEGXRServiceImpl


### PR DESCRIPTION
Updates the list of registered services in ```services.properties``` to include the new ```JPEGXRService``` added in https://github.com/openmicroscopy/bioformats/pull/2648.