### PR TITLE
Location NPE fix

### DIFF
--- a/src/main/java/loci/common/Location.java
+++ b/src/main/java/loci/common/Location.java
@@ -125,11 +125,11 @@ public class Location {
   }
 
   public Location(String parent, String child) {
-    this(parent + File.separator + child);
+    this(parent == null ? child : parent + File.separator + child);
   }
 
   public Location(Location parent, String child) {
-    this(parent.getAbsolutePath(), child);
+    this(parent == null ? (String) null : parent.getAbsolutePath(), child);
   }
 
   // -- Location API methods --

--- a/src/main/java/loci/common/Location.java
+++ b/src/main/java/loci/common/Location.java
@@ -620,7 +620,9 @@ public class Location {
 
   /* @see java.io.File#getParentFile() */
   public Location getParentFile() {
-    return new Location(getParent());
+    String parent = this.getParent();
+    if (parent == null) return null;
+    return new Location(parent);
   }
 
   /* @see java.io.File#getPath() */

--- a/src/test/java/loci/common/utests/LocationTest.java
+++ b/src/test/java/loci/common/utests/LocationTest.java
@@ -178,7 +178,7 @@ public class LocationTest {
   
   @Test
   public void testParentNull() {
-    Location nullParent = new Location("nullParentFile", null);
+    Location nullParent = new Location(null, "nullParentFile");
     assertEquals(nullParent.getName(), null, nullParent.getParentFile());
   }
 

--- a/src/test/java/loci/common/utests/LocationTest.java
+++ b/src/test/java/loci/common/utests/LocationTest.java
@@ -179,9 +179,9 @@ public class LocationTest {
   @Test
   public void testParentNull() {
     Location nullParent = new Location((String) null, "nullParentFile");
-    assertEquals(nullParent.getName(), null, nullParent.getParentFile());
+    assertEquals(nullParent.getName(), String.valueOf("null"), nullParent.getParentFile());
     nullParent = new Location((Location) null, "nullParentFile");
-    assertEquals(nullParent.getName(), null, nullParent.getParentFile());
+    assertEquals(nullParent.getName(), String.valueOf("null"), nullParent.getParentFile());
   }
 
   @Test

--- a/src/test/java/loci/common/utests/LocationTest.java
+++ b/src/test/java/loci/common/utests/LocationTest.java
@@ -178,7 +178,9 @@ public class LocationTest {
   
   @Test
   public void testParentNull() {
-    Location nullParent = new Location(null, "nullParentFile");
+    Location nullParent = new Location((String) null, "nullParentFile");
+    assertEquals(nullParent.getName(), null, nullParent.getParentFile());
+    nullParent = new Location((Location) null, "nullParentFile");
     assertEquals(nullParent.getName(), null, nullParent.getParentFile());
   }
 

--- a/src/test/java/loci/common/utests/LocationTest.java
+++ b/src/test/java/loci/common/utests/LocationTest.java
@@ -175,6 +175,12 @@ public class LocationTest {
         file.getParentFile().getAbsolutePath());
     }
   }
+  
+  @Test
+  public void testParentNull() {
+    Location nullParent = new Location("nullParentFile", null);
+    assertEquals(nullParent.getName(), null, nullParent.getParentFile());
+  }
 
   @Test
   public void testIsDirectory() {

--- a/src/test/java/loci/common/utests/LocationTest.java
+++ b/src/test/java/loci/common/utests/LocationTest.java
@@ -33,6 +33,7 @@
 package loci.common.utests;
 
 import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
 
 import java.io.File;
 import java.io.IOException;
@@ -179,9 +180,9 @@ public class LocationTest {
   @Test
   public void testParentNull() {
     Location nullParent = new Location((String) null, "nullParentFile");
-    assertEquals(nullParent.getName(), String.valueOf("null"), nullParent.getParentFile());
+    assertNull(nullParent.getParentFile());
     nullParent = new Location((Location) null, "nullParentFile");
-    assertEquals(nullParent.getName(), String.valueOf("null"), nullParent.getParentFile());
+    assertNull(nullParent.getParentFile());
   }
 
   @Test


### PR DESCRIPTION
Issue was raised on the mailing list: http://lists.openmicroscopy.org.uk/pipermail/ome-users/2017-July/006557.html

From discussions since then it was decided to adapt the same contract as used in https://docs.oracle.com/javase/8/docs/api/java/io/File.html#getParentFile-- and return null if the parent does not exist rather than throwing a `NullPointerException`

To test:
- Ensure builds and tests are all green