### PR TITLE
Adjust tests following new website deployment

### DIFF
--- a/src/test/java/loci/common/utests/LocationTest.java
+++ b/src/test/java/loci/common/utests/LocationTest.java
@@ -89,14 +89,14 @@ public class LocationTest {
       new Location(validFile.getAbsolutePath()),
       new Location(invalidPath),
       new Location(tmpDirectory),
-      new Location("http://www.openmicroscopy.org/site/foo/products/bio-formats"),
-      new Location("https://www.openmicroscopy.org/site/products/images"),
-      new Location("https://www.openmicroscopy.org/site/products/images/foo"),
+      new Location("http://www.openmicroscopy.org/"),
+      new Location("https://www.openmicroscopy.org/"),
+      new Location("https://www.openmicroscopy.org/nonexisting"),
       new Location(hiddenFile)
     };
 
     exists = new boolean[] {
-      true, false, true, false, true, false, true
+      true, false, true, true, true, false, true
     };
 
     isDirectory = new boolean[] {
@@ -108,7 +108,7 @@ public class LocationTest {
     };
 
     mode = new String[] {
-      "rw", "", "rw", "", "r", "","rw"
+      "rw", "", "rw", "r", "r", "","rw"
     };
 
     isRemote = new boolean[] {


### PR DESCRIPTION
Noticed while investigating the timeouts in https://github.com/ome/ome-common-java/pull/12

The LocationTest of ome-common-java is using some hardcoded URLs and the tests seem
to be hanging following the deployment of the new website. This PR updates these tests to use the root of the new website in HTTP and HTTPS as well as a non-existing URL.

The concern with these tests has always been the dependency on an external resource albeit one we are maintaining actively /cc @kennethgillen While mocking would be a better unit test, an alternative here would be to use https://github.com/ome/ome-common-java instead.