### PR TITLE
Location parent Javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -298,7 +298,7 @@
         <configuration>
           <failOnError>false</failOnError>
           <links>
-            <link>http://docs.oracle.com/javase/7/docs/api/</link>
+            <link>http://docs.oracle.com/javase/8/docs/api/</link>
           </links>
         </configuration>
         <executions>
@@ -455,7 +455,7 @@
         <configuration>
           <failOnError>false</failOnError>
           <links>
-            <link>http://docs.oracle.com/javase/7/docs/api/</link>
+            <link>http://docs.oracle.com/javase/8/docs/api/</link>
           </links>
         </configuration>
       </plugin>

--- a/src/main/java/loci/common/Location.java
+++ b/src/main/java/loci/common/Location.java
@@ -53,7 +53,7 @@ import com.google.common.collect.MapMaker;
 
 /**
  * Pseudo-extension of {@link java.io.File} that supports reading over HTTP
- * (among  other things).
+ * (among other things).
  * It is strongly recommended to use this instead of java.io.File.
  */
 public class Location {

--- a/src/main/java/loci/common/Location.java
+++ b/src/main/java/loci/common/Location.java
@@ -52,8 +52,8 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.MapMaker;
 
 /**
- * Pseudo-extension of java.io.File that supports reading over HTTP (among
- * other things).
+ * Pseudo-extension of {@link java.io.File} that supports reading over HTTP
+ * (among  other things).
  * It is strongly recommended to use this instead of java.io.File.
  */
 public class Location {
@@ -602,9 +602,13 @@ public class Location {
   }
 
   /**
-   * Returns the name of this file's parent directory, i.e. the path name prefix
-   * and every name in the path name sequence except for the last.
-   * If this file does not have a parent directory, then null is returned.
+   * Returns the pathname string of this abstract pathname's parent, or null if
+   * this pathname does not have a parent directory.
+   *
+   * The parent of an abstract pathname consists of the pathname's prefix, if
+   * any, and each name in the pathname's name sequence except for the last.
+   * If the name sequence is empty then the pathname does not name a parent
+   * directory.
    *
    * @see java.io.File#getParent()
    */
@@ -618,7 +622,17 @@ public class Location {
     return file.getParent();
   }
 
-  /* @see java.io.File#getParentFile() */
+  /**
+   * Returns the abstract pathname of this abstract pathname's parent, or null
+   * if this pathname does not name a parent directory.
+   *
+   * The parent of an abstract pathname consists of the pathname's prefix, if
+   * any, and each name in the pathname's name sequence except for the last.
+   * If the name sequence is empty then the pathname does not name a parent
+   * directory.
+   *
+   * @see java.io.File#getParentFile()
+   */
   public Location getParentFile() {
     String parent = this.getParent();
     if (parent == null) return null;


### PR DESCRIPTION
Following https://github.com/ome/ome-common-java/pull/12, reviews the Javadoc of the modified methods to improve the link with the upstream `java.io.File`.

- uses Java 8  rather than Java 7 for external linking so that the Javadoc links go to the anchor
- document the contracts of Javadoc for `getParent` and `getParentFile` by copying the Javadoc of `java.io.File` as the description still applies generically to `Location` methods

To test this PR, run `mvn javadoc:javadoc` and check the description of the two methods above are correct and the see also blocks appear and link to the correct place (can be compared with the current Javadoc at http://javadoc.io/doc/org.openmicroscopy/ome-common/5.3.2).
