### PR TITLE
Reduce calls to RandomAccessFile.setLength in NIOFileHandle

### DIFF
--- a/src/main/java/loci/common/NIOFileHandle.java
+++ b/src/main/java/loci/common/NIOFileHandle.java
@@ -214,7 +214,7 @@ public class NIOFileHandle extends AbstractNIOHandle {
   /* @see IRandomAccess.close() */
   @Override
   public void close() throws IOException {
-    if (raf.length() != length()) {
+    if (isReadWrite && channel.isOpen() && raf.length() != length()) {
       raf.setLength(length());
     }
     raf.close();

--- a/src/main/java/loci/common/NIOFileHandle.java
+++ b/src/main/java/loci/common/NIOFileHandle.java
@@ -105,6 +105,8 @@ public class NIOFileHandle extends AbstractNIOHandle {
   /** The original length of the file. */
   private Long defaultLength;
 
+  private long effectiveLength;
+
   // -- Constructors --
 
   /**
@@ -121,6 +123,7 @@ public class NIOFileHandle extends AbstractNIOHandle {
       mapMode = FileChannel.MapMode.READ_WRITE;
     }
     raf = new RandomAccessFile(file, mode);
+    effectiveLength = raf.length();
     channel = raf.getChannel();
     byteBufferProvider = new NIOByteBufferProvider(channel, mapMode);
     buffer(position, 0);
@@ -199,8 +202,9 @@ public class NIOFileHandle extends AbstractNIOHandle {
   @Override
   public void setLength(long length) throws IOException {
     if (raf.length() < length) {
-      raf.setLength(length);
+      raf.setLength(length + getBufferSize());
     }
+    effectiveLength = length;
     raf.seek(length - 1);
     buffer = null;
   }
@@ -210,6 +214,9 @@ public class NIOFileHandle extends AbstractNIOHandle {
   /* @see IRandomAccess.close() */
   @Override
   public void close() throws IOException {
+    if (raf.length() != length()) {
+      raf.setLength(length());
+    }
     raf.close();
   }
 
@@ -225,7 +232,7 @@ public class NIOFileHandle extends AbstractNIOHandle {
     if (defaultLength != null) {
       return defaultLength;
     }
-    return raf.length();
+    return effectiveLength;
   }
 
   /* @see IRandomAccess.getOrder() */


### PR DESCRIPTION
Instead of calling ```raf.setLength``` with the exact length required for the current write, this increases the length by ```NIOFileHandle.getBufferSize()``` in anticipation of future writes.  ```NIOFileHandle.close()``` then reconciles any discrepancy between the actual and expected file lengths, so that there are no extra bytes in the file.  This was the least invasive change I could think of, but happy to discuss if anyone has other thoughts.

See https://trac.openmicroscopy.org/ome/ticket/6931 and https://trello.com/c/OimiHAQY/175-profile-tiff-writing-on-windows.  This does have a noticeable impact on the performance of ```bfconvert``` on Windows; in the test case on the ticket, local Windows times are now down to ~52s vs ~95s.