### PR TITLE
StreamHandle: fix subtle bug when seeking more than 1 MB backward

### DIFF
--- a/src/main/java/loci/common/StreamHandle.java
+++ b/src/main/java/loci/common/StreamHandle.java
@@ -156,8 +156,10 @@ public abstract class StreamHandle implements IRandomAccess {
     fp = pos;
 
     if (diff < 0) {
+      // resetStream sets the fp to 0
       resetStream();
-      diff = fp;
+      diff = pos;
+      fp = pos;
     }
     int skipped = stream.skipBytes((int) diff);
     while (skipped < diff) {
@@ -165,6 +167,7 @@ public abstract class StreamHandle implements IRandomAccess {
       if (n == 0) break;
       skipped += n;
     }
+    markManager();
   }
 
   /* @see IRandomAccess.write(ByteBuffer) */

--- a/src/test/java/loci/common/utests/URLHandleTest.java
+++ b/src/test/java/loci/common/utests/URLHandleTest.java
@@ -38,7 +38,6 @@ import java.io.EOFException;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.util.Arrays;
 
 import loci.common.Constants;
 import loci.common.HandleException;
@@ -70,7 +69,6 @@ public class URLHandleTest {
     FileOutputStream out = new FileOutputStream(tmpFile);
     out.write("hello, world!\n".getBytes(Constants.ENCODING));
     byte[] emptyBuffer = new byte[EMPTY_BUFFER_SIZE];
-    Arrays.fill(emptyBuffer, (byte) 0);
     out.write(emptyBuffer);
     out.write("goodbye, world!\n".getBytes(Constants.ENCODING));
     out.close();


### PR DESCRIPTION
Originally reported as part of Harmony format support, see https://github.com/glencoesoftware/bioformats/pull/4

f5e4cac updates ```URLHandleTest``` to create a failing test exhibiting the problem.  518f31b is a port of https://github.com/glencoesoftware/bioformats/pull/4/commits/84fa9b6aea4c5d06c3f8d43e1964413a25e99b06, which should result in the test passing.

To test, check that building and running unit tests with f5e4cac alone results in a single test failure.  Building and running unit tests with both commits together should result in all tests passing.