### PR TITLE
Reduce memory usage when reading large text files

### DIFF
--- a/src/main/java/loci/common/DataTools.java
+++ b/src/main/java/loci/common/DataTools.java
@@ -76,8 +76,11 @@ public final class DataTools {
       throw new IOException("File too large");
     }
     int len = (int) idLen;
-    String data = in.readString(len);
+    byte[] b = new byte[len];
+    in.readFully(b);
     in.close();
+    String data = new String(b, Constants.ENCODING);
+    b = null;
     return data;
   }
 


### PR DESCRIPTION
Partial backport of a private PR.

Test data is in ```data_repo/inbox/ome-common-java-24```, and includes a 66MB ```test.txt``` and the following test class:

```
import loci.common.DataTools;

public class Test {
    public static void main(String[] args) throws Exception {
      String file = args[0];
      int readCount = Integer.parseInt(args[1]);
      int successful = 0;

      try {
      for (int i=0; i<readCount; i++) {
        DataTools.readFile(file);
        successful++;
      }
      }
      catch (OutOfMemoryError e) {
        /* debug */ System.out.println("* stopped early on OOM");
      }
      /* debug */ System.out.println("successfully read " + file + " " + successful + " times");
    }
}
```

Without this change:

```
$ java -mx400m Test test.txt 10
...
successfully read test.txt 10 times
$ java -mx390m Test test.txt 10
...
* stopped early on OOM
successfully read test.txt 0 times
```

With this change:

```
$ java -mx300m Test test.txt 10
...
successfully read test.txt 10 times
$ java -mx290m Test test.txt 10
...
* stopped early on OOM
successfully read test.txt 0 times
```

i.e. there should be a reproducible 25% reduction in the minimum amount of memory required to read the test file.  The original use case was large Micromanager acquisitions, where the *_metadata.txt file is tens or even >100 MB.