### PR TITLE
Maven updates part 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 target
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.20.1</version>
+        <version>2.21.0</version>
         <configuration>
           <suiteXmlFiles>
             <suiteXmlFile>src/test/java/loci/common/utests/testng-template.xml</suiteXmlFile>
@@ -313,7 +313,7 @@
 
       <plugin>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.5</version>
+        <version>3.5.1</version>
       </plugin>
 
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -426,21 +426,4 @@
       </build>
     </profile>
   </profiles>
-
-  <reporting>
-    <plugins>
-      <!-- Generate javadocs as part of site generation. -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.0.0</version>
-        <configuration>
-          <failOnError>false</failOnError>
-          <links>
-            <link>http://docs.oracle.com/javase/7/docs/api/</link>
-          </links>
-        </configuration>
-      </plugin>
-    </plugins>
-  </reporting>
 </project>


### PR DESCRIPTION
Followup for https://github.com/ome/ome-common-java/pull/16 to complete the cleanup for all decoupled components, including the new ones, and to do some further cleanup:

- Update maven plugin versions so that all components are using the same set
- Drop building of javadocs in the "site" phase; it's now done in the "build" phase so that we can use them for javadoc and documentation linkchecking in downstream components
- Update the `.gitignore` files to drop old and unnecessary stuff inherited from bioformats.

Testing: Check that all travis, appveyor builds are green, and that the east-ci merge build is green.