### PR TITLE
Fix all Javadoc warnings

### DIFF
--- a/src/main/java/loci/common/AbstractNIOHandle.java
+++ b/src/main/java/loci/common/AbstractNIOHandle.java
@@ -40,7 +40,7 @@ import java.io.IOException;
  * @see IRandomAccess
  * @see java.io.RandomAccessFile
  *
- * @author Chris Allan <callan at blackcat dot ca>
+ * @author Chris Allan (callan at blackcat dot ca)
  */
 public abstract class AbstractNIOHandle implements IRandomAccess {
 

--- a/src/main/java/loci/common/BZip2Handle.java
+++ b/src/main/java/loci/common/BZip2Handle.java
@@ -52,6 +52,7 @@ public class BZip2Handle extends StreamHandle {
   /**
    * Construct a new BZip2Handle corresponding to the given file.
    *
+   * @param file the path to a file on disk
    * @throws HandleException if the given file is not a BZip2 file.
    */
   public BZip2Handle(String file) throws IOException {
@@ -77,7 +78,14 @@ public class BZip2Handle extends StreamHandle {
 
   // -- BZip2Handle API methods --
 
-  /** Returns true if the given filename is a BZip2 file. */
+  /**
+   * Returns true if the given filename is a BZip2 file.
+   *
+   * @param file the path to a file on disk
+   * @return true if file's extension is .bz2 and the
+   *         first 2 bytes are the BZip2 magic marker
+   * @throws IOException if the file is not readable
+   */
   public static boolean isBZip2File(String file) throws IOException {
     if (!file.toLowerCase().endsWith(".bz2")) {
       return false;

--- a/src/main/java/loci/common/ByteArrayHandle.java
+++ b/src/main/java/loci/common/ByteArrayHandle.java
@@ -60,11 +60,20 @@ public class ByteArrayHandle extends AbstractNIOHandle {
   /**
    * Creates a random access byte stream to read from, and
    * write to, the bytes specified by the byte[] argument.
+   *
+   * @param bytes byte array to work with
    */
   public ByteArrayHandle(byte[] bytes) {
     buffer = ByteBuffer.wrap(bytes);
   }
 
+  /**
+   *
+   * Creates a random access byte stream to read from, and
+   * write to, the supplied ByteBuffer.
+   *
+   * @param bytes ByteBuffer used for reading and writing
+   */
   public ByteArrayHandle(ByteBuffer bytes) {
     buffer = bytes;
   }
@@ -86,7 +95,11 @@ public class ByteArrayHandle extends AbstractNIOHandle {
 
   // -- ByteArrayHandle API methods --
 
-  /** Gets the byte array backing this FileHandle. */
+  /**
+   * Gets a byte array representing the current state of this ByteArrayHandle.
+   *
+   * @return a byte array representation of the backing ByteBuffer
+   */
   public byte[] getBytes() {
     return buffer.array();
   }

--- a/src/main/java/loci/common/CBZip2InputStream.java
+++ b/src/main/java/loci/common/CBZip2InputStream.java
@@ -237,6 +237,8 @@ public class CBZip2InputStream extends InputStream {
    * to skip the first two bytes. Otherwise this constructor will
    * throw an exception. </p>
    *
+   * @param in stream from which to read BZip2 data; expected to be
+   *   set to the first byte past the 2 byte magic marker
    * @throws IOException
    *   if the stream content is malformed or an I/O error occurs.
    * @throws NullPointerException

--- a/src/main/java/loci/common/DataTools.java
+++ b/src/main/java/loci/common/DataTools.java
@@ -68,7 +68,16 @@ public final class DataTools {
 
   private DataTools() { }
 
-  /** Reads the contents of the given file into a string. */
+  /**
+   * Reads the contents of the given file into a string.
+   *
+   * @param id name of the file to read
+   *           this can be any name supported by Location,
+   *           not necessarily a file on disk
+   * @return the complete contents of the specified file
+   * @throws IOException if the file cannot be read or is larger than 2GB
+   * @see Location#getMappedId(String)
+   */
   public static String readFile(String id) throws IOException {
     RandomAccessInputStream in = new RandomAccessInputStream(id);
     long idLen = in.length();
@@ -87,6 +96,12 @@ public final class DataTools {
    * Translates up to the first len bytes of a byte array beyond the given
    * offset to a short. If there are fewer than len bytes available,
    * the MSBs are all assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of bytes to use for translation
+   * @param off offset to the first byte in the array
+   * @param len number of bytes to use
+   * @param little true if the bytes are provided in little-endian order
+   * @return the short value that results from concatenating the specified bytes
    */
   public static short bytesToShort(byte[] bytes, int off, int len,
     boolean little)
@@ -104,6 +119,11 @@ public final class DataTools {
    * Translates up to the first 2 bytes of a byte array beyond the given
    * offset to a short. If there are fewer than 2 bytes available
    * the MSBs are all assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of bytes to use for translation
+   * @param off offset to the first byte in the array
+   * @param little true if the bytes are provided in little-endian order
+   * @return the short value that results from concatenating the specified bytes
    */
   public static short bytesToShort(byte[] bytes, int off, boolean little) {
     return bytesToShort(bytes, off, 2, little);
@@ -113,6 +133,10 @@ public final class DataTools {
    * Translates up to the first 2 bytes of a byte array to a short.
    * If there are fewer than 2 bytes available, the MSBs are all
    * assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of bytes to use for translation
+   * @param little true if the bytes are provided in little-endian order
+   * @return the short value that results from concatenating the specified bytes
    */
   public static short bytesToShort(byte[] bytes, boolean little) {
     return bytesToShort(bytes, 0, 2, little);
@@ -122,6 +146,12 @@ public final class DataTools {
    * Translates up to the first len bytes of a byte array byond the given
    * offset to a short. If there are fewer than len bytes available,
    * the MSBs are all assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of unsigned bytes to use for translation
+   * @param off offset to the first byte in the array
+   * @param len number of bytes to use
+   * @param little true if the bytes are provided in little-endian order
+   * @return the short value that results from concatenating the specified bytes
    */
   public static short bytesToShort(short[] bytes, int off, int len,
     boolean little)
@@ -138,6 +168,12 @@ public final class DataTools {
    * Translates up to the first 2 bytes of a byte array byond the given
    * offset to a short. If there are fewer than 2 bytes available,
    * the MSBs are all assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of unsigned bytes to be translated to a short
+   * @param off offset into array of bytes; should be non-negative and less than
+   *        the length of the array
+   * @param little true if the bytes are provided in little-endian order
+   * @return the short value that results from concatenating the specified bytes
    */
   public static short bytesToShort(short[] bytes, int off, boolean little) {
     return bytesToShort(bytes, off, 2, little);
@@ -147,6 +183,10 @@ public final class DataTools {
    * Translates up to the first 2 bytes of a byte array to a short.
    * If there are fewer than 2 bytes available, the MSBs are all
    * assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of unsigned bytes to be translated to a short
+   * @param little true if the bytes are provided in little-endian order
+   * @return the short value that results from concatenating the specified bytes
    */
   public static short bytesToShort(short[] bytes, boolean little) {
     return bytesToShort(bytes, 0, 2, little);
@@ -156,6 +196,12 @@ public final class DataTools {
    * Translates up to the first len bytes of a byte array beyond the given
    * offset to an int. If there are fewer than len bytes available,
    * the MSBs are all assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of bytes to be translated to a int
+   * @param off offset to the first byte in the array
+   * @param len number of bytes to use
+   * @param little true if the bytes are provided in little-endian order
+   * @return the int value that results from concatenating the specified bytes
    */
   public static int bytesToInt(byte[] bytes, int off, int len,
     boolean little)
@@ -173,6 +219,11 @@ public final class DataTools {
    * Translates up to the first 4 bytes of a byte array beyond the given
    * offset to an int. If there are fewer than 4 bytes available,
    * the MSBs are all assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of bytes to be translated to a int
+   * @param off offset to the first byte in the array
+   * @param little true if the bytes are provided in little-endian order
+   * @return the int value that results from concatenating the specified bytes
    */
   public static int bytesToInt(byte[] bytes, int off, boolean little) {
     return bytesToInt(bytes, off, 4, little);
@@ -182,6 +233,11 @@ public final class DataTools {
    * Translates up to the first 4 bytes of a byte array to an int.
    * If there are fewer than 4 bytes available, the MSBs are all
    * assumed to be zero (regardless of endianness).
+   *
+   *
+   * @param bytes array of bytes to be translated to a int
+   * @param little true if the bytes are provided in little-endian order
+   * @return the int value that results from concatenating the specified bytes
    */
   public static int bytesToInt(byte[] bytes, boolean little) {
     return bytesToInt(bytes, 0, 4, little);
@@ -191,6 +247,12 @@ public final class DataTools {
    * Translates up to the first len bytes of a byte array beyond the given
    * offset to an int. If there are fewer than len bytes available,
    * the MSBs are all assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of unsigned bytes to be translated to a int
+   * @param off offset to the first byte in the array
+   * @param len number of bytes to use
+   * @param little true if the bytes are provided in little-endian order
+   * @return the int value that results from concatenating the specified bytes
    */
   public static int bytesToInt(short[] bytes, int off, int len,
     boolean little)
@@ -207,6 +269,11 @@ public final class DataTools {
    * Translates up to the first 4 bytes of a byte array beyond the given
    * offset to an int. If there are fewer than 4 bytes available,
    * the MSBs are all assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of unsigned bytes to be translated to a int
+   * @param off offset to the first byte in the array
+   * @param little true if the bytes are provided in little-endian order
+   * @return the int value that results from concatenating the specified bytes
    */
   public static int bytesToInt(short[] bytes, int off, boolean little) {
     return bytesToInt(bytes, off, 4, little);
@@ -216,6 +283,10 @@ public final class DataTools {
    * Translates up to the first 4 bytes of a byte array to an int.
    * If there are fewer than 4 bytes available, the MSBs are all
    * assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of unsigned bytes to be translated to a int
+   * @param little true if the bytes are provided in little-endian order
+   * @return the int value that results from concatenating the specified bytes
    */
   public static int bytesToInt(short[] bytes, boolean little) {
     return bytesToInt(bytes, 0, 4, little);
@@ -225,6 +296,12 @@ public final class DataTools {
    * Translates up to the first len bytes of a byte array beyond the given
    * offset to a float. If there are fewer than len bytes available,
    * the MSBs are all assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of bytes to be translated to a float
+   * @param off offset to the first byte in the array
+   * @param len number of bytes to use
+   * @param little true if the bytes are provided in little-endian order
+   * @return the float value that results from concatenating the specified bytes
    */
   public static float bytesToFloat(byte[] bytes, int off, int len,
     boolean little)
@@ -236,6 +313,11 @@ public final class DataTools {
    * Translates up to the first 4 bytes of a byte array beyond a given
    * offset to a float. If there are fewer than 4 bytes available,
    * the MSBs are all assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of bytes to be translated to a float
+   * @param off offset to the first byte in the array
+   * @param little true if the bytes are provided in little-endian order
+   * @return the float value that results from concatenating the specified bytes
    */
   public static float bytesToFloat(byte[] bytes, int off, boolean little) {
     return bytesToFloat(bytes, off, 4, little);
@@ -245,6 +327,10 @@ public final class DataTools {
    * Translates up to the first 4 bytes of a byte array to a float.
    * If there are fewer than 4 bytes available, the MSBs are all
    * assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of bytes to be translated to a float
+   * @param little true if the bytes are provided in little-endian order
+   * @return the float value that results from concatenating the specified bytes
    */
   public static float bytesToFloat(byte[] bytes, boolean little) {
     return bytesToFloat(bytes, 0, 4, little);
@@ -254,6 +340,12 @@ public final class DataTools {
    * Translates up to the first len bytes of a byte array beyond a given
    * offset to a float. If there are fewer than len bytes available,
    * the MSBs are all assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of unsigned bytes to be translated to a float
+   * @param off offset to the first byte in the array
+   * @param len number of bytes to use
+   * @param little true if the bytes are provided in little-endian order
+   * @return the float value that results from concatenating the specified bytes
    */
   public static float bytesToFloat(short[] bytes, int off, int len,
     boolean little)
@@ -265,6 +357,11 @@ public final class DataTools {
    * Translates up to the first 4 bytes of a byte array beyond a given
    * offset to a float. If there are fewer than 4 bytes available,
    * the MSBs are all assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of unsigned bytes to be translated to a float
+   * @param off offset to the first byte in the array
+   * @param little true if the bytes are provided in little-endian order
+   * @return the float value that results from concatenating the specified bytes
    */
   public static float bytesToFloat(short[] bytes, int off, boolean little) {
     return bytesToFloat(bytes, off, 4, little);
@@ -274,6 +371,10 @@ public final class DataTools {
    * Translates up to the first 4 bytes of a byte array to a float.
    * If there are fewer than 4 bytes available, the MSBs are all
    * assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of unsigned bytes to be translated to a float
+   * @param little true if the bytes are provided in little-endian order
+   * @return the float value that results from concatenating the specified bytes
    */
   public static float bytesToFloat(short[] bytes, boolean little) {
     return bytesToFloat(bytes, 0, 4, little);
@@ -283,6 +384,12 @@ public final class DataTools {
    * Translates up to the first len bytes of a byte array beyond the given
    * offset to a long. If there are fewer than len bytes available,
    * the MSBs are all assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of bytes to be translated to a long
+   * @param off offset to the first byte in the array
+   * @param len number of bytes to use
+   * @param little true if the bytes are provided in little-endian order
+   * @return the long value that results from concatenating the specified bytes
    */
   public static long bytesToLong(byte[] bytes, int off, int len,
     boolean little)
@@ -300,6 +407,11 @@ public final class DataTools {
    * Translates up to the first 8 bytes of a byte array beyond the given
    * offset to a long. If there are fewer than 8 bytes available,
    * the MSBs are all assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of bytes to be translated to a long
+   * @param off offset to the first byte in the array
+   * @param little true if the bytes are provided in little-endian order
+   * @return the long value that results from concatenating the specified bytes
    */
   public static long bytesToLong(byte[] bytes, int off, boolean little) {
     return bytesToLong(bytes, off, 8, little);
@@ -309,6 +421,10 @@ public final class DataTools {
    * Translates up to the first 8 bytes of a byte array to a long.
    * If there are fewer than 8 bytes available, the MSBs are all
    * assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of bytes to be translated to a long
+   * @param little true if the bytes are provided in little-endian order
+   * @return the long value that results from concatenating the specified bytes
    */
   public static long bytesToLong(byte[] bytes, boolean little) {
     return bytesToLong(bytes, 0, 8, little);
@@ -318,6 +434,12 @@ public final class DataTools {
    * Translates up to the first len bytes of a byte array beyond the given
    * offset to a long. If there are fewer than len bytes available,
    * the MSBs are all assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of unsigned bytes to be translated to a long
+   * @param off offset to the first byte in the array
+   * @param len number of bytes to use
+   * @param little true if the bytes are provided in little-endian order
+   * @return the long value that results from concatenating the specified bytes
    */
   public static long bytesToLong(short[] bytes, int off, int len,
     boolean little)
@@ -334,6 +456,11 @@ public final class DataTools {
    * Translates up to the first 8 bytes of a byte array beyond the given
    * offset to a long. If there are fewer than 8 bytes available,
    * the MSBs are all assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of unsigned bytes to be translated to a long
+   * @param off offset to the first byte in the array
+   * @param little true if the bytes are provided in little-endian order
+   * @return the long value that results from concatenating the specified bytes
    */
   public static long bytesToLong(short[] bytes, int off, boolean little) {
     return bytesToLong(bytes, off, 8, little);
@@ -343,6 +470,10 @@ public final class DataTools {
    * Translates up to the first 8 bytes of a byte array to a long.
    * If there are fewer than 8 bytes available, the MSBs are all
    * assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of unsigned bytes to be translated to a long
+   * @param little true if the bytes are provided in little-endian order
+   * @return the long value that results from concatenating the specified bytes
    */
   public static long bytesToLong(short[] bytes, boolean little) {
     return bytesToLong(bytes, 0, 8, little);
@@ -352,6 +483,12 @@ public final class DataTools {
    * Translates up to the first len bytes of a byte array beyond the given
    * offset to a double. If there are fewer than len bytes available,
    * the MSBs are all assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of bytes to be translated to a double
+   * @param off offset to the first byte in the array
+   * @param len number of bytes to use
+   * @param little true if the bytes are provided in little-endian order
+   * @return the double value that results from concatenating the specified bytes
    */
   public static double bytesToDouble(byte[] bytes, int off, int len,
     boolean little)
@@ -363,6 +500,11 @@ public final class DataTools {
    * Translates up to the first 8 bytes of a byte array beyond the given
    * offset to a double. If there are fewer than 8 bytes available,
    * the MSBs are all assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of bytes to be translated to a double
+   * @param off offset to the first byte in the array
+   * @param little true if the bytes are provided in little-endian order
+   * @return the double value that results from concatenating the specified bytes
    */
   public static double bytesToDouble(byte[] bytes, int off,
     boolean little)
@@ -374,6 +516,10 @@ public final class DataTools {
    * Translates up to the first 8 bytes of a byte array to a double.
    * If there are fewer than 8 bytes available, the MSBs are all
    * assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of bytes to be translated to a double
+   * @param little true if the bytes are provided in little-endian order
+   * @return the double value that results from concatenating the specified bytes
    */
   public static double bytesToDouble(byte[] bytes, boolean little) {
     return bytesToDouble(bytes, 0, 8, little);
@@ -383,6 +529,12 @@ public final class DataTools {
    * Translates up to the first len bytes of a byte array beyond the given
    * offset to a double. If there are fewer than len bytes available,
    * the MSBs are all assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of unsigned bytes to be translated to a double
+   * @param off offset to the first byte in the array
+   * @param len number of bytes to use
+   * @param little true if the bytes are provided in little-endian order
+   * @return the double value that results from concatenating the specified bytes
    */
   public static double bytesToDouble(short[] bytes, int off, int len,
     boolean little)
@@ -394,6 +546,11 @@ public final class DataTools {
    * Translates up to the first 8 bytes of a byte array beyond the given
    * offset to a double. If there are fewer than 8 bytes available,
    * the MSBs are all assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of unsigned bytes to be translated to a double
+   * @param off offset to the first byte in the array
+   * @param little true if the bytes are provided in little-endian order
+   * @return the double value that results from concatenating the specified bytes
    */
   public static double bytesToDouble(short[] bytes, int off,
     boolean little)
@@ -405,12 +562,22 @@ public final class DataTools {
    * Translates up to the first 8 bytes of a byte array to a double.
    * If there are fewer than 8 bytes available, the MSBs are all
    * assumed to be zero (regardless of endianness).
+   *
+   * @param bytes array of unsigned bytes to be translated to a double
+   * @param little true if the bytes are provided in little-endian order
+   * @return the double value that results from concatenating the specified bytes
    */
   public static double bytesToDouble(short[] bytes, boolean little) {
     return bytesToDouble(bytes, 0, 8, little);
   }
 
-  /** Translates the given byte array into a String of hexadecimal digits. */
+  /**
+   * Translates the given byte array into a String of hexadecimal digits.
+   *
+   * @param b the array of bytes to parse
+   * @return a string of length <code>2 * b.length</code> representing the
+   *         hexadecimal digits of each byte in <code>b</code> concatenated
+   */
   public static String bytesToHex(byte[] b) {
     StringBuffer sb = new StringBuffer();
     for (int i=0; i<b.length; i++) {
@@ -423,6 +590,8 @@ public final class DataTools {
 
   /**
    * Parses the input string into a short
+   *
+   * @param value a String representation of a short value
    * @return {@code null} if the string could not be parsed
    */
   public static Short parseShort(String value) {
@@ -436,6 +605,8 @@ public final class DataTools {
 
   /**
    * Parses the input string into a byte
+   *
+   * @param value a String representation of a byte value
    * @return {@code null} if the string could not be parsed
    */
   public static Byte parseByte(String value) {
@@ -449,6 +620,8 @@ public final class DataTools {
 
   /**
    * Parses the input string into an integer
+   *
+   * @param value a String representation of an int value
    * @return {@code null} if the string could not be parsed
    */
   public static Integer parseInteger(String value) {
@@ -462,6 +635,8 @@ public final class DataTools {
 
   /**
    * Parses the input string into a long
+   *
+   * @param value a String representation of a long value
    * @return {@code null} if the string could not be parsed
    */
   public static Long parseLong(String value) {
@@ -476,6 +651,7 @@ public final class DataTools {
   /**
    * Parses the input string into a float accounting for the locale decimal
    * separator
+   * @param value a String representation of a float value
    * @return {@code null} if the string could not be parsed
    */
   public static Float parseFloat(String value) {
@@ -491,6 +667,7 @@ public final class DataTools {
   /**
    * Parses the input string into a double accounting for the locale decimal
    * separator
+   * @param value a String representation of a double value
    * @return {@code null} if the string could not be parsed
    */
   public static Double parseDouble(String value) {
@@ -506,6 +683,10 @@ public final class DataTools {
   /**
    * Normalizes the decimal separator for the user's locale.
    * @deprecated Use {@link #parseDouble(String)} instead
+   *
+   * @param value the String representation of a double value,
+   *        which may contain invalid characters that prevent parsing
+   * @return see above
    */
   @Deprecated
   public static String sanitizeDouble(String value) {
@@ -524,42 +705,78 @@ public final class DataTools {
 
   // -- Word decoding - primitive types to bytes --
 
-  /** Translates the short value into an array of two bytes. */
+  /**
+   * Translates the short value into an array of two bytes.
+   *
+   * @param value the short to be split into bytes
+   * @param little true if the returned bytes should be in little-endian order
+   * @return byte array with length 2
+   */
   public static byte[] shortToBytes(short value, boolean little) {
     byte[] v = new byte[2];
     unpackBytes(value, v, 0, 2, little);
     return v;
   }
 
-  /** Translates the int value into an array of four bytes. */
+  /**
+   * Translates the int value into an array of four bytes.
+   *
+   * @param value the int to be split into bytes
+   * @param little true if the returned bytes should be in little-endian order
+   * @return byte array with length 4
+   */
   public static byte[] intToBytes(int value, boolean little) {
     byte[] v = new byte[4];
     unpackBytes(value, v, 0, 4, little);
     return v;
   }
 
-  /** Translates the float value into an array of four bytes. */
+  /**
+   * Translates the float value into an array of four bytes.
+   *
+   * @param value the float to be split into bytes
+   * @param little true if the returned bytes should be in little-endian order
+   * @return byte array with length 4
+   */
   public static byte[] floatToBytes(float value, boolean little) {
     byte[] v = new byte[4];
     unpackBytes(Float.floatToIntBits(value), v, 0, 4, little);
     return v;
   }
 
-  /** Translates the long value into an array of eight bytes. */
+  /**
+   * Translates the long value into an array of eight bytes.
+   *
+   * @param value the long to be split into bytes
+   * @param little true if the returned bytes should be in little-endian order
+   * @return byte array with length 8
+   */
   public static byte[] longToBytes(long value, boolean little) {
     byte[] v = new byte[8];
     unpackBytes(value, v, 0, 8, little);
     return v;
   }
 
-  /** Translates the double value into an array of eight bytes. */
+  /**
+   * Translates the double value into an array of eight bytes.
+   *
+   * @param value the double to be split into bytes
+   * @param little true if the returned bytes should be in little-endian order
+   * @return byte array with length 8
+   */
   public static byte[] doubleToBytes(double value, boolean little) {
     byte[] v = new byte[8];
     unpackBytes(Double.doubleToLongBits(value), v, 0, 8, little);
     return v;
   }
 
-  /** Translates an array of short values into an array of byte values. */
+  /**
+   * Translates an array of short values into an array of byte values.
+   *
+   * @param values the shorts to be split into bytes
+   * @param little true if the returned bytes should be in little-endian order
+   * @return byte array with length <code>2 * values.length</code>
+   */
   public static byte[] shortsToBytes(short[] values, boolean little) {
     byte[] v = new byte[values.length * 2];
     for (int i=0; i<values.length; i++) {
@@ -568,7 +785,13 @@ public final class DataTools {
     return v;
   }
 
-  /** Translates an array of int values into an array of byte values. */
+  /**
+   * Translates an array of int values into an array of byte values.
+   *
+   * @param values the ints to be split into bytes
+   * @param little true if the returned bytes should be in little-endian order
+   * @return byte array with length <code>4 * values.length</code>
+   */
   public static byte[] intsToBytes(int[] values, boolean little) {
     byte[] v = new byte[values.length * 4];
     for (int i=0; i<values.length; i++) {
@@ -577,7 +800,13 @@ public final class DataTools {
     return v;
   }
 
-  /** Translates an array of float values into an array of byte values. */
+  /**
+   * Translates an array of float values into an array of byte values.
+   *
+   * @param values the floats to be split into bytes
+   * @param little true if the returned bytes should be in little-endian order
+   * @return byte array with length <code>4 * values.length</code>
+   */
   public static byte[] floatsToBytes(float[] values, boolean little) {
     byte[] v = new byte[values.length * 4];
     for (int i=0; i<values.length; i++) {
@@ -586,7 +815,13 @@ public final class DataTools {
     return v;
   }
 
-  /** Translates an array of long values into an array of byte values. */
+  /**
+   * Translates an array of long values into an array of byte values.
+   *
+   * @param values the longs to be split into bytes
+   * @param little true if the returned bytes should be in little-endian order
+   * @return byte array with length <code>8 * values.length</code>
+   */
   public static byte[] longsToBytes(long[] values, boolean little) {
     byte[] v = new byte[values.length * 8];
     for (int i=0; i<values.length; i++) {
@@ -595,7 +830,13 @@ public final class DataTools {
     return v;
   }
 
-  /** Translates an array of double values into an array of byte values. */
+  /**
+   * Translates an array of double values into an array of byte values.
+   *
+   * @param values the doubles to be split into bytes
+   * @param little true if the returned bytes should be in little-endian order
+   * @return byte array with length <code>8 * values.length</code>
+   */
   public static byte[] doublesToBytes(double[] values, boolean little) {
     byte[] v = new byte[values.length * 8];
     for (int i=0; i<values.length; i++) {
@@ -608,6 +849,11 @@ public final class DataTools {
    * Translates nBytes of the given long and places the result in the
    * given byte array.
    *
+   * @param value the long to be split into bytes
+   * @param buf the byte array in which to store the unpacked bytes
+   * @param ndx the offset to the first byte in the array
+   * @param nBytes the number of unpacked bytes
+   * @param little true if the unpacked bytes should be in little-endian order
    * @throws IllegalArgumentException
    *   if the specified indices fall outside the buffer
    */
@@ -638,6 +884,7 @@ public final class DataTools {
    *   (e.g. if bpp == 2, we should return an array of type short).
    * @param fp If set and bpp == 4 or bpp == 8, then return floats or doubles.
    * @param little Whether byte array is in little-endian order.
+   * @return an array of primitives
    */
   public static Object makeDataArray(byte[] b,
     int bpp, boolean fp, boolean little)
@@ -769,33 +1016,74 @@ public final class DataTools {
 
   // -- Byte swapping --
 
+  /**
+   * Reverse the order of bytes in the given short.
+   *
+   * @param x short value to byte swap
+   * @return short value resulting from byte swapping <code>x</code>
+   */
   public static short swap(short x) {
     return (short) ((x << 8) | ((x >> 8) & 0xFF));
   }
-
+  /**
+   * Reverse the order of bytes in the given char.
+   *
+   * @param x char value to byte swap
+   * @return char value resulting from byte swapping <code>x</code>
+   */
   public static char swap(char x) {
     return (char) ((x << 8) | ((x >> 8) & 0xFF));
   }
 
+  /**
+   * Reverse the order of bytes in the given int.
+   *
+   * @param x int value to byte swap
+   * @return int value resulting from byte swapping <code>x</code>
+   */
   public static int swap(int x) {
     return (swap((short) x) << 16) | (swap((short) (x >> 16)) & 0xFFFF);
   }
 
+  /**
+   * Reverse the order of bytes in the given long.
+   *
+   * @param x long value to byte swap
+   * @return long value resulting from byte swapping <code>x</code>
+   */
   public static long swap(long x) {
     return ((long) swap((int) x) << 32) | (swap((int) (x >> 32)) & 0xFFFFFFFFL);
   }
 
+  /**
+   * Reverse the order of bytes in the given float.
+   *
+   * @param x float value to byte swap
+   * @return float value resulting from byte swapping <code>x</code>
+   */
   public static float swap(float x) {
     return Float.intBitsToFloat(swap(Float.floatToIntBits(x)));
   }
 
+  /**
+   * Reverse the order of bytes in the given double.
+   *
+   * @param x double value to byte swap
+   * @return double value resulting from byte swapping <code>x</code>
+   */
   public static double swap(double x) {
     return Double.longBitsToDouble(swap(Double.doubleToLongBits(x)));
   }
 
   // -- Strings --
 
-  /** Remove null bytes from a string. */
+  /**
+   * Remove null bytes from a string.
+   *
+   * @param toStrip String from which to remove null bytes
+   * @return a String copy of <code>toStrip</code> with all
+   *         null (0) bytes removed
+   */
   public static String stripString(String toStrip) {
     StringBuffer s = new StringBuffer();
     for (int i=0; i<toStrip.length(); i++) {
@@ -806,7 +1094,29 @@ public final class DataTools {
     return s.toString().trim();
   }
 
-  /** Check if two filenames have the same prefix. */
+  /**
+   * Check if two filenames have the same prefix.
+   * The order in which the filenames are supplied does not matter.
+   *
+   * Examples:
+   *  s1 = /tmp/path.txt
+   *  s2 = /home/anonymous/path.png
+   *  returns true
+   *
+   *  s1 = /tmp/path1.txt
+   *  s2 = /tmp/path246.txt
+   *  returns false
+   *
+   *  s1 = /tmp/path.txt
+   *  s2 = /tmp/path246.txt
+   *  returns true
+   *
+   * @param s1 first String filename to compare
+   * @param s2 second String filename to compare
+   * @return true if the relative filename without suffix for
+   *         either input filename is a substring of the other
+   *         input filenames' relative filename without suffix
+   */
   public static boolean samePrefix(String s1, String s2) {
     if (s1 == null || s2 == null) return false;
     int n1 = s1.indexOf('.');
@@ -821,7 +1131,14 @@ public final class DataTools {
     return sub1.equals(sub2) || sub1.startsWith(sub2) || sub2.startsWith(sub1);
   }
 
-  /** Remove unprintable characters from the given string. */
+  /**
+   * Remove unprintable characters from the given string.
+   *
+   * @param s String from which to remove unprintable characters
+   * @return a String copy of <code>s</code> with tabs, newlines,
+   *         and control characters removed
+   * @see Character#isISOControl(char)
+   */
   public static String sanitize(String s) {
     if (s == null) return null;
     StringBuffer buf = new StringBuffer(s);
@@ -839,6 +1156,10 @@ public final class DataTools {
   /**
    * Normalize the given float array so that the minimum value maps to 0.0
    * and the maximum value maps to 1.0.
+   *
+   * @param data array of <code>float</code> values to normalize
+   * @return array of <code>float</code> values in the range
+   *         <code>[0.0, 1.0]</code>
    */
   public static float[] normalizeFloats(float[] data) {
     float[] rtn = new float[data.length];
@@ -873,6 +1194,10 @@ public final class DataTools {
   /**
    * Normalize the given double array so that the minimum value maps to 0.0
    * and the maximum value maps to 1.0.
+   *
+   * @param data array of <code>double</code> values to normalize
+   * @return array of <code>double</code> values in the range
+   *         <code>[0.0, 1.0]</code>
    */
   public static double[] normalizeDoubles(double[] data) {
     double[] rtn = new double[data.length];
@@ -982,7 +1307,15 @@ public final class DataTools {
     return total;
   }
 
-  /** Returns true if the given value is contained in the given array. */
+  /**
+   * Returns true if the given value is contained in the given array.
+   *
+   * @param array an array of ints to search
+   * @param value the int for which to search
+   * @return true if <code>array</code> contains at least one occurence of
+   *         <code>value</code>
+   * @see #indexOf(int[], int)
+   */
   public static boolean containsValue(int[] array, int value) {
     return indexOf(array, value) != -1;
   }
@@ -990,6 +1323,11 @@ public final class DataTools {
   /**
    * Returns the index of the first occurrence of the given value in the given
    * array. If the value is not in the array, returns -1.
+   *
+   * @param array an array of ints to search
+   * @param value the int for which to search
+   * @return the index of the first occurence of <code>value</code> in
+   *         <code>array</code>, or -1 if <code>value</code> is not found
    */
   public static int indexOf(int[] array, int value) {
     for (int i=0; i<array.length; i++) {
@@ -1001,6 +1339,11 @@ public final class DataTools {
   /**
    * Returns the index of the first occurrence of the given value in the given
    * Object array. If the value is not in the array, returns -1.
+   *
+   * @param array an array of Objects to search
+   * @param value the Object for which to search
+   * @return the index of the first occurence of <code>value</code> in
+   *         <code>array</code>, or -1 if <code>value</code> is not found
    */
   public static int indexOf(Object[] array, Object value) {
     for (int i=0; i<array.length; i++) {

--- a/src/main/java/loci/common/DateTools.java
+++ b/src/main/java/loci/common/DateTools.java
@@ -110,18 +110,53 @@ public final class DateTools {
   /**
    * Converts from two-word tick representation to milliseconds.
    * Mainly useful in conjunction with COBOL date conversion.
+   *
+   * @param hi the upper 32 bits of the tick count
+   * @param lo the lower 32 bits of the tick count
+   * @return the number of milliseconds corresponding to the tick count,
+   *         where 1 tick = 100 ns
    */
   public static long getMillisFromTicks(long hi, long lo) {
     long ticks = ((hi << 32) | lo);
     return ticks / 10000; // 100 ns = 0.0001 ms
   }
 
-  /** Converts the given timestamp into an ISO8601 date. */
+  /**
+   * Converts the given timestamp into an ISO8601 date.
+   *
+   * @param stamp the format-dependent timestamp
+   * @param format the format in which <code>stamp</code> is stored.
+   *               This is used to select the epoch value used for normalizing
+   *               the timestamp to milliseconds since the UNIX epoch.  Valid
+   *               values are #UNIX, #COBOL, #MICROSOFT, #ZVI, and #ALT_ZVI.
+   * @return an ISO 8601 formatted timestamp
+   * @see #UNIX_EPOCH
+   * @see #COBOL_EPOCH
+   * @see #MICROSOFT_EPOCH
+   * @see #ZVI_EPOCH
+   * @see #ALT_ZVI_EPOCH
+   */
   public static String convertDate(long stamp, int format) {
     return convertDate(stamp, format, ISO8601_FORMAT);
   }
 
-  /** Converts the given timestamp into a date string with the given format. */
+  /**
+   * Converts the given timestamp into a date string with the given format.
+   *
+   * @param stamp the format-dependent timestamp
+   * @param format the format in which <code>stamp</code> is stored.
+   *               This is used to select the epoch value used for normalizing
+   *               the timestamp to milliseconds since the UNIX epoch.  Valid
+   *               values are #UNIX, #COBOL, #MICROSOFT, #ZVI, and #ALT_ZVI.
+   * @param outputFormat the pattern used for formatting the timestamp
+   * @return a timestamp in the specified output format
+   * @see #UNIX_EPOCH
+   * @see #COBOL_EPOCH
+   * @see #MICROSOFT_EPOCH
+   * @see #ZVI_EPOCH
+   * @see #ALT_ZVI_EPOCH
+   * @see DateTimeFormat
+   */
   public static String convertDate(long stamp, int format, String outputFormat)
   {
     return convertDate(stamp, format, outputFormat, false);
@@ -132,6 +167,21 @@ public final class DateTools {
    *
    * If correctTimeZoneForGMT is set, then the timestamp will be interpreted
    * as being relative to GMT and not the local time zone.
+   *
+   * @param stamp the format-dependent timestamp
+   * @param format the format in which <code>stamp</code> is stored.
+   *               This is used to select the epoch value used for normalizing
+   *               the timestamp to milliseconds since the UNIX epoch.  Valid
+   *               values are #UNIX, #COBOL, #MICROSOFT, #ZVI, and #ALT_ZVI.
+   * @param outputFormat the pattern used for formatting the timestamp
+   * @param correctTimeZoneForGMT true if the timestamp is relative to GMT
+   * @return a timestamp in the specified output format
+   * @see #UNIX_EPOCH
+   * @see #COBOL_EPOCH
+   * @see #MICROSOFT_EPOCH
+   * @see #ZVI_EPOCH
+   * @see #ALT_ZVI_EPOCH
+   * @see DateTimeFormat
    */
   public static String convertDate(long stamp, int format, String outputFormat,
     boolean correctTimeZoneForGMT)
@@ -181,6 +231,8 @@ public final class DateTools {
    * @param date      The date to parse as a Joda timestamp
    * @param format    The date format to parse the string date
    * @param separator The separator for milliseconds
+   * @return the Joda Instant object representing the timestamp
+   * @see Instant
    */
   protected static Instant parseDate(String date, String format, String separator) {
 
@@ -244,6 +296,7 @@ public final class DateTools {
    *
    * @param date   The date to format as ISO 8601
    * @param format The date format to parse the string date
+   * @return an ISO 8601 formatted timestamp
    */
   public static String formatDate(String date, String format) {
     return formatDate(date, format, false);
@@ -257,6 +310,7 @@ public final class DateTools {
    * @param date      The date to format as ISO 8601
    * @param format    The date format to parse the string date
    * @param separator The separator for milliseconds
+   * @return an ISO 8601 formatted timestamp
    */
   public static String formatDate(String date, String format, String separator) {
     return formatDate(date, format, false, separator);
@@ -268,6 +322,7 @@ public final class DateTools {
    * @param date    The date to format as ISO 8601.
    * @param format  The date format to parse the string date
    * @param lenient Whether or not to leniently parse the date.
+   * @return an ISO 8601 formatted timestamp
    */
   public static String formatDate(String date, String format, boolean lenient) {
    return formatDate(date, format, false, null);
@@ -280,6 +335,7 @@ public final class DateTools {
    * @param format    The date format to parse the string date
    * @param lenient   Whether or not to leniently parse the date.
    * @param separator The separator for milliseconds
+   * @return an ISO 8601 formatted timestamp
    */
   public static String formatDate(String date, String format, boolean lenient, String separator) {
     if (date == null) return null;
@@ -309,6 +365,7 @@ public final class DateTools {
    *
    * @param date    The date to format as ISO 8601
    * @param formats The date possible formats to parse the string date
+   * @return an ISO 8601 formatted timestamp
    */
   public static String formatDate(String date, String[] formats) {
     return formatDate(date, formats, false, null);
@@ -323,6 +380,7 @@ public final class DateTools {
    * @param date    The date to format as ISO 8601.
    * @param formats The date possible formats to parse the string date
    * @param lenient Whether or not to leniently parse the date.
+   * @return an ISO 8601 formatted timestamp
    */
   public static String formatDate(String date, String[] formats,
     boolean lenient)
@@ -338,6 +396,7 @@ public final class DateTools {
    * @param date    The date to format as ISO 8601
    * @param formats The date possible formats to parse the string date
    * @param separator  The separator for milliseconds
+   * @return an ISO 8601 formatted timestamp
    */
   public static String formatDate(String date, String[] formats, String separator) {
     return formatDate(date, formats, false, separator);
@@ -350,6 +409,7 @@ public final class DateTools {
    * @param formats    The date possible formats to parse the string date
    * @param lenient    Whether or not to leniently parse the date.
    * @param separator  The separator for milliseconds
+   * @return an ISO 8601 formatted timestamp
    */
   public static String formatDate(String date, String[] formats,
     boolean lenient, String separator)
@@ -394,7 +454,7 @@ public final class DateTools {
   }
 
   /**
-   * Returns a timestamp for the current timezone in a
+   * @return a timestamp for the current timezone in a
    * human-readable locale-independent format ("YYYY-MM-DD HH:MM:SS")
    */
   public static String getTimestamp() {
@@ -402,7 +462,7 @@ public final class DateTools {
   }
 
   /**
-   * Returns a timestamp for the current timezone in a format suitable
+   * @return a timestamp for the current timezone in a format suitable
    * for a filename in a locale-independent format
    * ("YYYY-MM-DD_HH-MM-SS")
    */

--- a/src/main/java/loci/common/DebugTools.java
+++ b/src/main/java/loci/common/DebugTools.java
@@ -58,7 +58,12 @@ public final class DebugTools {
 
   // -- DebugTools methods --
 
-  /** Extracts the given exception's corresponding stack trace to a string. */
+  /**
+   * Extracts the given exception's corresponding stack trace to a string.
+   *
+   * @param t the Throwable from which to extract a stack trace
+   * @return the complete stack trace as a String
+   */
   public static String getStackTrace(Throwable t) {
     try {
       ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -179,6 +184,11 @@ public final class DebugTools {
   /**
    * This method uses reflection to scan the values of the given class's
    * static fields, returning the first matching field's name.
+   *
+   * @param c the class to scan
+   * @param value the int value of the field to find
+   * @return the name of the field, or the string representation of
+   *         <code>value</code> if a matching field is not found
    */
   public static String getFieldName(Class<?> c, int value) {
     Field[] fields = c.getDeclaredFields();

--- a/src/main/java/loci/common/FileHandle.java
+++ b/src/main/java/loci/common/FileHandle.java
@@ -59,6 +59,10 @@ public class FileHandle implements IRandomAccess {
   /**
    * Creates a random access file stream to read from, and
    * optionally to write to, the file specified by the File argument.
+   *
+   * @param file a {@link File} representing a file on disk
+   * @param mode a valid access mode as defined in {@link RandomAccessFile}
+   * @throws FileNotFoundException if the file does not exist
    */
   public FileHandle(File file, String mode) throws FileNotFoundException {
     raf = new RandomAccessFile(file, mode);
@@ -67,6 +71,10 @@ public class FileHandle implements IRandomAccess {
   /**
    * Creates a random access file stream to read from, and
    * optionally to write to, a file with the specified name.
+   *
+   * @param name the path to a file on disk
+   * @param mode a valid access mode as defined in {@link RandomAccessFile}
+   * @throws FileNotFoundException if the file does not exist
    */
   public FileHandle(String name, String mode) throws FileNotFoundException {
     raf = new RandomAccessFile(name, mode);
@@ -74,7 +82,9 @@ public class FileHandle implements IRandomAccess {
 
   // -- FileHandle API methods --
 
-  /** Gets the random access file object backing this FileHandle. */
+  /**
+   * @return the {@link RandomAccessFile} object backing this FileHandle.
+   */
   public RandomAccessFile getRandomAccessFile() { return raf; }
 
   // -- IRandomAccess API methods --

--- a/src/main/java/loci/common/GZipHandle.java
+++ b/src/main/java/loci/common/GZipHandle.java
@@ -53,6 +53,7 @@ public class GZipHandle extends StreamHandle {
   /**
    * Construct a new GZipHandle for the given file.
    *
+   * @param file the path to the GZip file
    * @throws HandleException if the given file name is not a GZip file.
    */
   public GZipHandle(String file) throws IOException {
@@ -76,7 +77,11 @@ public class GZipHandle extends StreamHandle {
 
   // -- GZipHandle API methods --
 
-  /** Returns true if the given filename is a gzip file. */
+  /**
+   * @param file the path to the GZip file
+   * @return true if the given filename is a gzip file
+   * @throws IOException if the file cannot be read
+   */
   public static boolean isGZipFile(String file) throws IOException {
     if (!file.toLowerCase().endsWith(".gz")) return false;
 

--- a/src/main/java/loci/common/IRandomAccess.java
+++ b/src/main/java/loci/common/IRandomAccess.java
@@ -47,23 +47,36 @@ public interface IRandomAccess extends DataInput, DataOutput {
   /**
    * Closes this random access stream and releases
    * any system resources associated with the stream.
+   *
+   * @throws IOException if the underlying stream(s) could not be closed
    */
   void close() throws IOException;
 
-  /** Returns the current offset in this stream. */
+  /**
+   * Returns the current offset in this stream.
+   *
+   * @return the current byte offset within the file; expected to be
+   *         non-negative and less than the value of #length()
+   * @throws IOException if the offset cannot be retrieved
+   */
   long getFilePointer() throws IOException;
 
-  /** Returns the length of this stream. */
+  /**
+   * Returns the length of this stream.
+   *
+   * @return the length in bytes of the stream
+   * @throws IOException if the length cannot be retrieved
+   */
   long length() throws IOException;
 
   /**
-   * Returns the current order of the stream.
+   * Returns the current order (endianness) of the stream.
    * @return See above.
    */
   ByteOrder getOrder();
 
   /**
-   * Sets the byte order of the stream.
+   * Sets the byte order (endianness) of the stream.
    * @param order Order to set.
    */
   void setOrder(ByteOrder order);
@@ -72,45 +85,83 @@ public interface IRandomAccess extends DataInput, DataOutput {
    * Reads up to b.length bytes of data
    * from this stream into an array of bytes.
    *
+   * @param b the array to fill from this stream
    * @return the total number of bytes read into the buffer.
+   * @throws IOException if reading is not possible
    */
   int read(byte[] b) throws IOException;
 
   /**
    * Reads up to len bytes of data from this stream into an array of bytes.
    *
+   * @param b the array to fill from this stream
+   * @param off the offset in <code>b</code> from which to start filling;
+   *        expected to be non-negative and no greater than
+   *        <code>b.length - len</code>
+   * @param len the number of bytes to read; expected to be positive and
+   *        no greater than <code>b.length - offset</code>
    * @return the total number of bytes read into the buffer.
+   * @throws IOException if reading is not possible
    */
   int read(byte[] b, int off, int len) throws IOException;
 
   /**
    * Reads up to buffer.capacity() bytes of data
    * from this stream into a ByteBuffer.
+   *
+   * @param buffer the ByteBuffer to fill from this stream
+   * @return the total number of bytes read into the buffer.
+   * @throws IOException if reading is not possible
    */
   int read(ByteBuffer buffer) throws IOException;
 
   /**
    * Reads up to len bytes of data from this stream into a ByteBuffer.
    *
+   * @param buffer the ByteBuffer to fill from this stream
+   * @param offset the offset in <code>b</code> from which to start filling;
+   *        expected to be non-negative and no greater than
+   *        <code>buffer.capacity() - len</code>
+   * @param len the number of bytes to read; expected to be positive and
+   *        no greater than <code>buffer.capacity() - offset</code>
    * @return the total number of bytes read into the buffer.
+   * @throws IOException if reading is not possible
    */
   int read(ByteBuffer buffer, int offset, int len) throws IOException;
 
   /**
    * Sets the stream pointer offset, measured from the beginning
    * of this stream, at which the next read or write occurs.
+   *
+   * @param pos new byte offset (pointer) in the current stream.
+   *        Unless otherwise noted, may be larger or smaller than the
+   *        current pointer, but must be non-negative and less than the
+   *        value of #length()
+   * @throws IOException if <code>pos</code> is invalid or the seek fails
+   * @see #getFilePointer()
    */
   void seek(long pos) throws IOException;
 
   /**
    * Writes up to buffer.capacity() bytes of data from the given
    * ByteBuffer to this stream.
+   *
+   * @param buf the ByteBuffer containing bytes to write to this stream
+   * @throws IOException if writing is not possible
    */
   void write(ByteBuffer buf) throws IOException;
 
   /**
    * Writes up to len bytes of data from the given ByteBuffer to this
    * stream.
+   *
+   * @param buf the ByteBuffer containing bytes to write to this stream
+   * @param off the offset in <code>b</code> from which to start writing;
+   *        expected to be non-negative and no greater than
+   *        <code>buf.capacity() - len</code>
+   * @param len the number of bytes to write; expected to be positive and
+   *        no greater than <code>buf.capacity() - offset</code>
+   * @throws IOException if writing is not possible
    */
   void write(ByteBuffer buf, int off, int len) throws IOException;
 }

--- a/src/main/java/loci/common/IniList.java
+++ b/src/main/java/loci/common/IniList.java
@@ -43,7 +43,10 @@ import java.util.List;
  */
 public class IniList extends ArrayList<IniTable> {
 
-  /** Gets the table names (headers) in the list. */
+  /**
+   * Gets the table names (headers) in the list.
+   * @return a List containing the name of each {@link IniTable}
+   */
   public List<String> getHeaders() {
     List<String> headers = new ArrayList<String>();
     for (IniTable table : this) {
@@ -53,7 +56,13 @@ public class IniList extends ArrayList<IniTable> {
     return headers;
   }
 
-  /** Gets the table with the given name (header). */
+  /**
+   * Gets the table with the given name (header).
+   *
+   * @param tableName the name of the table to look up
+   * @return the {@link IniTable} representing the named table,
+   *         or null if no table with that name exists
+   */
   public IniTable getTable(String tableName) {
     for (IniTable table : this) {
       String header = table.get(IniTable.HEADER_KEY);
@@ -65,6 +74,9 @@ public class IniList extends ArrayList<IniTable> {
   /**
    * Flattens all of the INI tables into a single HashMap whose keys are
    * of the format "[table name] table key".
+   *
+   * @return a HashMap containing all key/value pairs in every {@link IniTable}
+   *         as described above
    */
   public HashMap<String, String> flattenIntoHashMap() {
     HashMap<String, String> h = new HashMap<String, String>();

--- a/src/main/java/loci/common/IniParser.java
+++ b/src/main/java/loci/common/IniParser.java
@@ -62,6 +62,8 @@ public class IniParser {
 
   /**
    * Set the String that identifies a comment.  Defaults to "#".
+   *
+   * @param delimiter the String used to identify comments
    */
   public void setCommentDelimiter(String delimiter) {
     commentDelimiter = delimiter;
@@ -72,12 +74,22 @@ public class IniParser {
    * line continues on the following line.
    *
    * By default, a '\' does continue the line.
+   *
+   * @param slashContinues true if a '\' at the end of a line signifies that
+   *        the line continues on the following line
    */
   public void setBackslashContinuesLine(boolean slashContinues) {
     this.slashContinues = slashContinues;
   }
 
-  /** Parses the INI-style configuration data from the given resource. */
+  /**
+   * Parses the INI-style configuration data from the given resource.
+   *
+   * @param path the name of the resource to read
+   * @return the IniList parsed from the named resource
+   * @see #openTextResource(String)
+   * @throws IOException if the resource cannot be read
+   */
   public IniList parseINI(String path)
     throws IOException
   {
@@ -87,6 +99,12 @@ public class IniParser {
   /**
    * Parses the INI-style configuration data from the given resource,
    * using the given class to find the resource.
+   *
+   * @param path the name of the resource to read
+   * @param c the Class to use for finding the named resource
+   * @return the IniList parsed from the named resource
+   * @see #openTextResource(String, Class)
+   * @throws IOException if the resource cannot be read
    */
   public IniList parseINI(String path, Class<?> c)
     throws IOException
@@ -96,6 +114,10 @@ public class IniParser {
 
   /**
    * Parses the INI-style wrapping the given file in a {@link BufferedReader}
+   *
+   * @param file the file on disk from which to read
+   * @return the IniList parsed from the file
+   * @throws IOException if the file cannot be read
    */
   public IniList parseINI(File file)
     throws IOException
@@ -121,7 +143,13 @@ public class IniParser {
     }
   }
 
-  /** Parses the INI-style configuration data from the given input stream. */
+  /**
+   * Parses the INI-style configuration data from the given input stream.
+   *
+   * @param in the BufferedReader stream from which to read
+   * @return the IniList parsed from the reader
+   * @throws IOException if the stream cannot be read
+   */
   public IniList parseINI(BufferedReader in)
     throws IOException
   {
@@ -186,12 +214,25 @@ public class IniParser {
 
   // -- Utility methods --
 
-  /** Opens a buffered reader for the given resource. */
+  /**
+   * Opens a buffered reader for the given resource.
+   *
+   * @param path the name of the resource to read
+   * @return the BufferedReader corresponding to the named resource
+   * @see #openTextResource(String)
+   */
   public static BufferedReader openTextResource(String path) {
     return openTextResource(path, IniParser.class);
   }
 
-  /** Opens a buffered reader for the given resource. */
+  /**
+   * Opens a buffered reader for the given resource.
+   *
+   * @param path the name of the resource to read
+   * @param c the Class to use for finding the named resource
+   * @return the BufferedReader corresponding to the named resource
+   * @see #openTextResource(String)
+   */
   public static BufferedReader openTextResource(String path, Class<?> c) {
     try {
       return new BufferedReader(new InputStreamReader(

--- a/src/main/java/loci/common/IniWriter.java
+++ b/src/main/java/loci/common/IniWriter.java
@@ -58,12 +58,25 @@ public class IniWriter {
   /**
    * Saves the given IniList to the given file.
    * If the given file already exists, then the IniList will be appended.
+   *
+   * @param ini the {@link IniList} to be written
+   * @param path the path to a writable file on disk
+   * @throws IOException if there is an error during writing
    */
   public void saveINI(IniList ini, String path) throws IOException {
     saveINI(ini, path, true);
   }
 
-  /** Saves the given IniList to the given file. */
+  /**
+   * Saves the given IniList to the given file.
+   *
+   * @param ini the {@link IniList} to be written
+   * @param path the path to a writable file on disk
+   * @param append true if the INI data should be appended to
+   *               the end of the file if it already exists
+   * @param sorted true if the INI keys should be sorted before writing
+   * @throws IOException if there is an error during writing
+   */
   public void saveINI(IniList ini, String path, boolean append, boolean sorted)
     throws IOException
   {
@@ -92,7 +105,15 @@ public class IniWriter {
     out.close();
   }
 
-  /** Saves the given IniList to the given file. */
+  /**
+   * Saves the given IniList to the given file.
+   *
+   * @param ini the {@link IniList} to be written
+   * @param path the path to a writable file on disk
+   * @param append true if the INI data should be appended to
+   *               the end of the file if it already exists
+   * @throws IOException if there is an error during writing
+   */
   public void saveINI(IniList ini, String path, boolean append)
     throws IOException
   {

--- a/src/main/java/loci/common/Location.java
+++ b/src/main/java/loci/common/Location.java
@@ -99,6 +99,13 @@ public class Location {
 
   // -- Constructors --
 
+  /**
+   * Construct a Location using the given path.
+   *
+   * @param pathname a URL, a file on disk, or a mapped name
+   * @see #getMappedId(String)
+   * @see #getMappedFile(String)
+   */
   public Location(String pathname) {
     LOGGER.trace("Location({})", pathname);
     if (pathname.contains("://")) {
@@ -118,16 +125,36 @@ public class Location {
     if (!isURL) file = new File(getMappedId(pathname));
   }
 
+  /**
+   * Construct a Location using the given file on disk.
+   *
+   * @param file a file on disk
+   */
   public Location(File file) {
     LOGGER.trace("Location({})", file);
     isURL = false;
     this.file = file;
   }
 
+  /**
+   * Construct a Location using the given directory and relative path.
+   * The two parameters are joined with a file separator and passed to
+   * #Location(String)
+   *
+   * @param parent the directory path name
+   * @param child the relative path name
+   */
   public Location(String parent, String child) {
     this(parent + File.separator + child);
   }
 
+  /**
+   * Construct a Location using the given directory and relative path.
+   *
+   * @param parent a Location representing the directory name
+   * @param child the relative path name
+   * @see #Location(String, String)
+   */
   public Location(Location parent, String child) {
     this(parent.getAbsolutePath(), child);
   }
@@ -206,6 +233,10 @@ public class Location {
    * using the original filename as the id assists format handlers with type
    * identification and pattern matching, and the id can be mapped to the
    * actual filename for reading the file's contents.
+   *
+   * @param id the mapped name
+   * @param filename the actual filename on disk.
+   *        If null, any existing mapping for <code>id</code> will be cleared.
    * @see #getMappedId(String)
    */
   public static void mapId(String id, String filename) {
@@ -215,7 +246,15 @@ public class Location {
     LOGGER.debug("Location.mapId: {} -> {}", id, filename);
   }
 
-  /** Maps the given id to the given IRandomAccess object. */
+  /**
+   * Maps the given id to the given IRandomAccess object.
+   *
+   * @param id the mapped name
+   * @param ira the IRandomAccess object that will be referenced by
+   *        <code>id</code>.  If null, any existing mapping for
+   *        <code>id</code> will be cleared.
+   * @see #getMappedFile(String)
+   */
   public static void mapFile(String id, IRandomAccess ira) {
     if (id == null) return;
     if (ira == null) getIdMap().remove(id);
@@ -230,6 +269,9 @@ public class Location {
    * the original filename is useful for checking the file extension and doing
    * pattern matching, but the renamed filename is required to read its
    * contents.
+   *
+   * @param id the mapped name
+   * @return the corresponding file name on disk, or null if there is no mapping
    * @see #mapId(String, String)
    */
   public static String getMappedId(String id) {
@@ -241,7 +283,13 @@ public class Location {
     return filename == null ? id : filename;
   }
 
-  /** Gets the random access handle for the given id. */
+  /**
+   * Gets the random access handle for the given id.
+   *
+   * @param id the mapped name
+   * @return the corresponding IRandomAccess, or null if there is no mapping
+   * @see #mapFile(String, IRandomAccess)
+   */
   public static IRandomAccess getMappedFile(String id) {
     if (getIdMap() == null) return null;
     IRandomAccess ira = null;
@@ -251,7 +299,13 @@ public class Location {
     return ira;
   }
 
-  /** Return the id mapping. */
+  /**
+   * Return the id mapping.
+   *
+   * @return the map from names to filesystem paths and IRandomAccess objects
+   * @see #mapId(String, String)
+   * @see #mapFile(String, IRandomAccess)
+   */
   public static HashMap<String, Object> getIdMap() {
     return idMap.get();
   }
@@ -259,6 +313,8 @@ public class Location {
   /**
    * Set the id mapping using the given HashMap.
    *
+   * @param map the new mapping from names to filesystem paths
+   *        and IRandomAccess objects
    * @throws IllegalArgumentException if the given HashMap is null.
    */
   public static void setIdMap(HashMap<String, Object> map) {
@@ -268,6 +324,12 @@ public class Location {
 
   /**
    * Gets an IRandomAccess object that can read from the given file.
+   *
+   * @param id the name for which to locate an IRandomAccess
+   * @return a previously mapped IRandomAccess, or a new IRandomAccess
+   *         according to the name's type (URL, filesystem path, etc.)
+   * @throws IOException if a valid IRandomAccess cannot be created
+   * @see #getHandle(String, boolean, boolean, int)
    * @see IRandomAccess
    */
   public static IRandomAccess getHandle(String id) throws IOException {
@@ -276,6 +338,13 @@ public class Location {
 
   /**
    * Gets an IRandomAccess object that can read from or write to the given file.
+   *
+   * @param id the name for which to locate an IRandomAccess
+   * @param writable true if the returned IRandomAccess should have write permission
+   * @return a previously mapped IRandomAccess, or a new IRandomAccess
+   *         according to the name's type (URL, filesystem path, etc.)
+   * @throws IOException if a valid IRandomAccess cannot be created
+   * @see #getHandle(String, boolean, boolean, int)
    * @see IRandomAccess
    */
   public static IRandomAccess getHandle(String id, boolean writable)
@@ -286,6 +355,15 @@ public class Location {
 
   /**
    * Gets an IRandomAccess object that can read from or write to the given file.
+   *
+   * @param id the name for which to locate an IRandomAccess
+   * @param writable true if the returned IRandomAccess should have write permission
+   * @param allowArchiveHandles true if checks for compressed/archive file types
+   *        (e.g. Zip, GZip, BZip2) should be enabled
+   * @return a previously mapped IRandomAccess, or a new IRandomAccess
+   *         according to the name's type (URL, filesystem path, etc.)
+   * @throws IOException if a valid IRandomAccess cannot be created
+   * @see #getHandle(String, boolean, boolean, int)
    * @see IRandomAccess
    */
   public static IRandomAccess getHandle(String id, boolean writable,
@@ -294,6 +372,20 @@ public class Location {
     return getHandle(id, writable, allowArchiveHandles, 0);
   }
 
+  /**
+   * Gets an IRandomAccess object that can read from or write to the given file.
+   *
+   * @param id the name for which to locate an IRandomAccess
+   * @param writable true if the returned IRandomAccess should have write permission
+   * @param allowArchiveHandles true if checks for compressed/archive file types
+   *        (e.g. Zip, GZip, BZip2) should be enabled
+   * @param bufferSize the buffer size to use when constructing a NIOFileHandle.
+   *        Ignored when non-positive.
+   * @return a previously mapped IRandomAccess, or a new IRandomAccess
+   *         according to the name's type (URL, filesystem path, etc.)
+   * @throws IOException if a valid IRandomAccess cannot be created
+   * @see IRandomAccess
+   */
   public static IRandomAccess getHandle(String id, boolean writable,
     boolean allowArchiveHandles, int bufferSize) throws IOException
   {
@@ -353,6 +445,9 @@ public class Location {
    * Return a list of all of the files in this directory.  If 'noHiddenFiles' is
    * set to true, then hidden files are omitted.
    *
+   * @param noHiddenFiles true if hidden files should be omitted
+   * @return an unsorted list of all relative files in the directory represented
+   *         by this Location
    * @see java.io.File#list()
    */
   public String[] list(boolean noHiddenFiles) {
@@ -439,6 +534,7 @@ public class Location {
    * the URL exists.
    * Otherwise, it will return true iff the file exists and is readable.
    *
+   * @return see above
    * @see java.io.File#canRead()
    */
   public boolean canRead() {
@@ -450,6 +546,7 @@ public class Location {
    * If the underlying location is a URL, this method will always return false.
    * Otherwise, it will return true iff the file exists and is writable.
    *
+   * @return see above
    * @see java.io.File#canWrite()
    */
   public boolean canWrite() {
@@ -538,6 +635,7 @@ public class Location {
    * If the pathname is a URL, then existence is determined based on whether
    * or not we can successfully read content from the URL.
    *
+   * @return true if there is a way to read bytes from this Location's name
    * @see java.io.File#exists()
    */
   public boolean exists() {
@@ -580,6 +678,9 @@ public class Location {
    * If the file is a URL, then the canonical path is equivalent to the
    * absolute path ({@link #getAbsolutePath()}).  Otherwise, this method
    * will delegate to {@link java.io.File#getCanonicalPath()}.
+   *
+   * @return see above
+   * @throws IOException if the path cannot be retrieved
    */
   public String getCanonicalPath() throws IOException {
     return isURL ? getAbsolutePath() : file.getCanonicalPath();
@@ -589,6 +690,7 @@ public class Location {
    * Returns the name of this file, i.e. the last name in the path name
    * sequence.
    *
+   * @return the relative path name
    * @see java.io.File#getName()
    */
   public String getName() {
@@ -606,6 +708,7 @@ public class Location {
    * and every name in the path name sequence except for the last.
    * If this file does not have a parent directory, then null is returned.
    *
+   * @return see above
    * @see java.io.File#getParent()
    */
   public String getParent() {
@@ -629,9 +732,8 @@ public class Location {
   }
 
   /**
-   * Tests whether or not this path name is absolute.
-   * If the path name is a URL, this method will always return true.
-   *
+   * @return true if this path name is absolute.
+   *         If the path name is a URL, this method will always return true.
    * @see java.io.File#isAbsolute()
    */
   public boolean isAbsolute() {
@@ -640,8 +742,7 @@ public class Location {
   }
 
   /**
-   * Returns true if this pathname exists and represents a directory.
-   *
+   * @return true if this pathname exists and represents a directory.
    * @see java.io.File#isDirectory()
    */
   public boolean isDirectory() {
@@ -654,8 +755,7 @@ public class Location {
   }
 
   /**
-   * Returns true if this pathname exists and represents a regular file.
-   *
+   * @return true if this pathname exists and represents a regular file.
    * @see java.io.File#exists()
    */
   public boolean isFile() {
@@ -664,9 +764,8 @@ public class Location {
   }
 
   /**
-   * Returns true if the pathname is 'hidden'.  This method will always
-   * return false if the pathname corresponds to a URL.
-   *
+   * @return true if the pathname is 'hidden'.  This method will always
+   *         return false if the pathname corresponds to a URL.
    * @see java.io.File#isHidden()
    */
   public boolean isHidden() {
@@ -682,10 +781,8 @@ public class Location {
   }
 
   /**
-   * Return the last modification time of this file, in milliseconds since
-   * the UNIX epoch.
-   * If the file does not exist, 0 is returned.
-   *
+   * @return the last modification time of this file, in milliseconds since
+   *         the UNIX epoch. If the file does not exist, 0 is returned.
    * @see java.io.File#lastModified()
    * @see java.net.URLConnection#getLastModified()
    */
@@ -704,6 +801,7 @@ public class Location {
   }
 
   /**
+   * @return the length of the file or stream in bytes
    * @see java.io.File#length()
    * @see java.net.URLConnection#getContentLength()
    */
@@ -722,18 +820,18 @@ public class Location {
   }
 
   /**
-   * Return a list of file names in this directory.  Hidden files will be
-   * included in the list.
-   * If this is not a directory, return null.
+   * @return a list of file names in this directory.  Hidden files will be
+   *         included in the list. If this is not a directory, return null.
+   * @see #list(boolean)
    */
   public String[] list() {
     return list(false);
   }
 
   /**
-   * Return a list of absolute files in this directory.  Hidden files will
-   * be included in the list.
-   * If this is not a directory, return null.
+   * @return a list of absolute files in this directory.  Hidden files will
+   *         be included in the list. If this is not a directory, return null.
+   * @see #list()
    */
   public Location[] listFiles() {
     String[] s = list();
@@ -747,8 +845,8 @@ public class Location {
   }
 
   /**
-   * Return the URL corresponding to this pathname.
-   *
+   * @return the URL corresponding to this pathname.
+   * @throws MalformedURLException if the pathname is not a valid URL
    * @see java.io.File#toURL()
    */
   public URL toURL() throws MalformedURLException {

--- a/src/main/java/loci/common/Location.java
+++ b/src/main/java/loci/common/Location.java
@@ -657,18 +657,37 @@ public class Location {
     return mappedId != null && new File(mappedId).exists();
   }
 
-  /* @see java.io.File#getAbsoluteFile() */
+  /**
+   * Return the absolute form of this abstract location.
+   *
+   * @return a Location representing @see #getAbsolutePath
+   * @see java.io.File#getAbsoluteFile()
+   */
   public Location getAbsoluteFile() {
     return new Location(getAbsolutePath());
   }
 
-  /* @see java.io.File#getAbsolutePath() */
+  /**
+   * Return the absolute form of this abstract location.
+   *
+   * @return a string representing the absolute path
+   * @see java.io.File#getAbsolutePath()
+   */
   public String getAbsolutePath() {
     LOGGER.trace("getAbsolutePath()");
     return isURL ? url.toExternalForm() : file.getAbsolutePath();
   }
 
-  /* @see java.io.File#getCanonicalFile() */
+  /**
+   * Returns the canonical path to this file.
+   * If the file is a URL, then the canonical path is equivalent to the
+   * absolute file ({@link #getAbsoluteFile()}). Otherwise, this method
+   * will delegate to {@link java.io.File#getCanonicalFile()}.
+   *
+   * @return see above
+   * @throws IOException if the canonical path cannot be constructed
+   * @see java.io.File#getCanonicalFile()
+   */
   public Location getCanonicalFile() throws IOException {
     return isURL ? getAbsoluteFile() : new Location(file.getCanonicalFile());
   }
@@ -721,17 +740,29 @@ public class Location {
     return file.getParent();
   }
 
-  /* @see java.io.File#getParentFile() */
+  /**
+   * Returns this file's parent directory.
+   *
+   * @return the Location representing {@link #getParent()}
+   * @see java.io.File#getParentFile()
+   */
   public Location getParentFile() {
     return new Location(getParent());
   }
 
-  /* @see java.io.File#getPath() */
+  /**
+   * Returns the file's path.
+   *
+   * @return this file's path name
+   * @see java.io.File#getPath()
+   */
   public String getPath() {
     return isURL ? url.getHost() + url.getPath() : file.getPath();
   }
 
   /**
+   * Returns whether or not this file's path is absolute.
+   *
    * @return true if this path name is absolute.
    *         If the path name is a URL, this method will always return true.
    * @see java.io.File#isAbsolute()
@@ -742,6 +773,8 @@ public class Location {
   }
 
   /**
+   * Returns whether or not this file is a directory.
+   *
    * @return true if this pathname exists and represents a directory.
    * @see java.io.File#isDirectory()
    */
@@ -755,6 +788,8 @@ public class Location {
   }
 
   /**
+   * Returns whether or not this file is a regular file (i.e. not a directory).
+   *
    * @return true if this pathname exists and represents a regular file.
    * @see java.io.File#exists()
    */
@@ -764,6 +799,8 @@ public class Location {
   }
 
   /**
+   * Returns whether or not this file is marked hidden by the filesystem.
+   *
    * @return true if the pathname is 'hidden'.  This method will always
    *         return false if the pathname corresponds to a URL.
    * @see java.io.File#isHidden()
@@ -781,6 +818,8 @@ public class Location {
   }
 
   /**
+   * Return the last modification time of the file.
+   *
    * @return the last modification time of this file, in milliseconds since
    *         the UNIX epoch. If the file does not exist, 0 is returned.
    * @see java.io.File#lastModified()
@@ -801,6 +840,8 @@ public class Location {
   }
 
   /**
+   * Return the file length in bytes.
+   *
    * @return the length of the file or stream in bytes
    * @see java.io.File#length()
    * @see java.net.URLConnection#getContentLength()
@@ -820,6 +861,9 @@ public class Location {
   }
 
   /**
+   * Return a list of relative file names in this directory, or null
+   * if this file is not a directory.
+   *
    * @return a list of file names in this directory.  Hidden files will be
    *         included in the list. If this is not a directory, return null.
    * @see #list(boolean)
@@ -829,6 +873,9 @@ public class Location {
   }
 
   /**
+   * Return a list of files in this directory, or null if this file is
+   * not a directory.
+   *
    * @return a list of absolute files in this directory.  Hidden files will
    *         be included in the list. If this is not a directory, return null.
    * @see #list()
@@ -845,6 +892,8 @@ public class Location {
   }
 
   /**
+   * Return a {@link URL} corresponding to this file.
+   *
    * @return the URL corresponding to this pathname.
    * @throws MalformedURLException if the pathname is not a valid URL
    * @see java.io.File#toURL()

--- a/src/main/java/loci/common/NIOByteBufferProvider.java
+++ b/src/main/java/loci/common/NIOByteBufferProvider.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
  *   <li>http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6417205</li>
  * </ul>
  *
- * @author Chris Allan <callan at blackcat dot ca>
+ * @author Chris Allan (callan at blackcat dot ca)
  */
 public class NIOByteBufferProvider {
 

--- a/src/main/java/loci/common/NIOFileHandle.java
+++ b/src/main/java/loci/common/NIOFileHandle.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
  * @see IRandomAccess
  * @see java.io.RandomAccessFile
  *
- * @author Chris Allan <callan at blackcat dot ca>
+ * @author Chris Allan (callan at blackcat dot ca)
  */
 public class NIOFileHandle extends AbstractNIOHandle {
 
@@ -110,6 +110,13 @@ public class NIOFileHandle extends AbstractNIOHandle {
   /**
    * Creates a random access file stream to read from, and
    * optionally to write to, the file specified by the File argument.
+   *
+   * @param file a {@link File} representing a file on disk
+   * @param mode the access mode; <code>r</code> (read only) and
+   *             <code>rw</code> (read/write) are supported
+   * @param bufferSize the size of the buffer used to speed up reading
+   *                   and writing
+   * @throws IOException if there is an error accessing the file
    */
   public NIOFileHandle(File file, String mode, int bufferSize)
     throws IOException
@@ -134,6 +141,11 @@ public class NIOFileHandle extends AbstractNIOHandle {
   /**
    * Creates a random access file stream to read from, and
    * optionally to write to, the file specified by the File argument.
+   *
+   * @param file a {@link File} representing a file on disk
+   * @param mode the access mode; <code>r</code> (read only) and
+   *             <code>rw</code> (read/write) are supported
+   * @throws IOException if there is an error accessing the file
    */
   public NIOFileHandle(File file, String mode) throws IOException {
     this(file, mode,
@@ -143,6 +155,11 @@ public class NIOFileHandle extends AbstractNIOHandle {
   /**
    * Creates a random access file stream to read from, and
    * optionally to write to, a file with the specified name.
+   *
+   * @param name the path to a file on disk
+   * @param mode the access mode; <code>r</code> (read only) and
+   *             <code>rw</code> (read/write) are supported
+   * @throws IOException if there is an error accessing the file
    */
   public NIOFileHandle(String name, String mode) throws IOException {
     this(new File(name), mode);
@@ -155,6 +172,8 @@ public class NIOFileHandle extends AbstractNIOHandle {
    *
    * Subsequent uses of the NIOFileHandle(String, String) and
    * NIOFileHandle(File, String) constructors will use this buffer size.
+   *
+   * @param size the new default buffer size
    */
   public static void setDefaultBufferSize(int size) {
     defaultBufferSize = size;
@@ -165,6 +184,8 @@ public class NIOFileHandle extends AbstractNIOHandle {
    *
    * Subsequent uses of the NIOFileHandle(String, String) and
    * NIOFileHandle(File, String) constructors will use this buffer size.
+   *
+   * @param size the new default buffer size
    */
   public static void setDefaultReadWriteBufferSize(int size) {
     defaultRWBufferSize = size;
@@ -172,12 +193,16 @@ public class NIOFileHandle extends AbstractNIOHandle {
 
   // -- FileHandle and Channel API methods --
 
-  /** Gets the random access file object backing this FileHandle. */
+  /**
+   * @return the random access file object backing this FileHandle.
+   */
   public RandomAccessFile getRandomAccessFile() {
     return raf;
   }
 
-  /** Gets the FileChannel from this FileHandle. */
+  /**
+   * @return the FileChannel from this FileHandle.
+   */
   public FileChannel getFileChannel() {
     try {
       channel.position(position);
@@ -188,7 +213,9 @@ public class NIOFileHandle extends AbstractNIOHandle {
     return channel;
   }
 
-  /** Gets the current buffer size. */
+  /**
+   * @return the current buffer size.
+   */
   public int getBufferSize() {
     return bufferSize;
   }

--- a/src/main/java/loci/common/NIOInputStream.java
+++ b/src/main/java/loci/common/NIOInputStream.java
@@ -76,26 +76,41 @@ public class NIOInputStream extends InputStream implements DataInput {
 
   // -- Constructors --
 
-  /** Constructs an NIOInputStream around the given file. */
+  /**
+   * Constructs an NIOInputStream around the given file.
+   *
+   * @param filename the path to a readable file on disk
+   * @throws IOException if the path is invalid or unreadable
+   */
   public NIOInputStream(String filename) throws IOException {
     this.filename = filename;
     file = new File(filename);
     raf = new FileHandle(file, "r");
   }
 
-  /** Constructs a random access stream around the given handle. */
+  /**
+   * Constructs a random access stream around the given handle.
+   *
+   * @param handle the {@link IRandomAccess} to wrap in a stream
+   */
   public NIOInputStream(IRandomAccess handle) {
     raf = handle;
   }
 
-  /** Constructs a random access stream around the given byte array. */
+  /**
+   * Constructs a random access stream around the given byte array.
+   *
+   * @param array the byte array to wrap in a stream
+   */
   public NIOInputStream(byte[] array) {
     this(new ByteArrayHandle(array));
   }
 
   // -- NIOInputStream API methods --
 
-  /** Returns the underlying InputStream. */
+  /**
+   * @return the underlying InputStream.
+   */
   public DataInputStream getInputStream() {
     return null;
   }
@@ -103,11 +118,18 @@ public class NIOInputStream extends InputStream implements DataInput {
   /**
    * Sets the number of bytes by which to extend the stream.  This only applies
    * to InputStream API methods.
+   *
+   * @param extend the number of bytes by which to extend the stream
    */
   public void setExtend(int extend) {
   }
 
-  /** Seeks to the given offset within the stream. */
+  /**
+   * Seeks to the given offset within the stream.
+   *
+   * @param pos the offset to which to seek
+   * @throws IOException if the seek is not successful
+   */
   public void seek(long pos) throws IOException {
     raf.seek(pos);
   }
@@ -118,12 +140,19 @@ public class NIOInputStream extends InputStream implements DataInput {
     return raf.readUnsignedByte();
   }
 
-  /** Gets the number of bytes in the file. */
+  /**
+   * Gets the number of bytes in the file.
+   *
+   * @return the length of the stream in bytes
+   * @throws IOException if the length cannot be retrieved
+   */
   public long length() throws IOException {
     return raf.length();
   }
 
-  /** Gets the current (absolute) file pointer. */
+  /**
+   * @return the current (absolute) file pointer.
+   */
   public long getFilePointer() {
     try {
       return raf.getFilePointer();
@@ -137,12 +166,18 @@ public class NIOInputStream extends InputStream implements DataInput {
   public void close() throws IOException {
   }
 
-  /** Sets the endianness of the stream. */
+  /**
+   * Sets the endianness of the stream.
+   *
+   * @param isLittleEndian true if the stream order is little-endian
+   */
   public void order(boolean isLittleEndian) {
     this.isLittleEndian = isLittleEndian;
   }
 
-  /** Gets the endianness of the stream. */
+  /**
+   * @return the endianness of the stream.
+   */
   public boolean isLittleEndian() {
     return isLittleEndian;
   }
@@ -150,6 +185,9 @@ public class NIOInputStream extends InputStream implements DataInput {
   /**
    * Reads a string ending with one of the characters in the given string.
    *
+   * @param lastChars string containing possible final characters for the returned string
+   * @return the smallest string that ends in one of the characters in <code>lastChars</code>
+   * @throws IOException If the maximum length (512 MB) is exceeded.
    * @see #findString(String...)
    */
   public String readString(String lastChars) throws IOException {
@@ -170,6 +208,7 @@ public class NIOInputStream extends InputStream implements DataInput {
    * @return The string from the initial position through the end of the
    *   terminating sequence, or through the end of the stream if no
    *   terminating sequence is found.
+   * @throws IOException If the maximum search length (512 MB) is exceeded.
    */
   public String findString(String... terminators) throws IOException {
     return findString(true, DEFAULT_BLOCK_SIZE, terminators);
@@ -189,6 +228,8 @@ public class NIOInputStream extends InputStream implements DataInput {
    * @return The string from the initial position through the end of the
    *   terminating sequence, or through the end of the stream if no
    *   terminating sequence is found, or null if saveString flag is unset.
+   * @throws IOException If saveString flag is set
+   *   and the maximum search length (512 MB) is exceeded.
    */
   public String findString(boolean saveString, String... terminators)
     throws IOException
@@ -206,6 +247,7 @@ public class NIOInputStream extends InputStream implements DataInput {
    * @return The string from the initial position through the end of the
    *   terminating sequence, or through the end of the stream if no
    *   terminating sequence is found.
+   * @throws IOException If the maximum search length (512 MB) is exceeded.
    */
   public String findString(int blockSize, String... terminators)
     throws IOException
@@ -350,12 +392,24 @@ public class NIOInputStream extends InputStream implements DataInput {
     return findString("\n");
   }
 
-  /** Read a string of arbitrary length, terminated by a null char. */
+  /**
+   * Read a string of arbitrary length, terminated by a null char.
+   *
+   * @return the smallest string such that the last character is a null byte
+   * @throws IOException if a null-terminated string is not found
+   * @see #findString(String...)
+   */
   public String readCString() throws IOException {
     return findString("\0");
   }
 
-  /** Read a string of length n. */
+  /**
+   * Read a string of length n.
+   *
+   * @param n the number of bytes to read
+   * @return a string representing the next <code>n</code> bytes in the stream
+   * @throws IOException if there is an error during reading
+   */
   public String readString(int n) throws IOException {
     byte[] b = new byte[n];
     readFully(b);

--- a/src/main/java/loci/common/RandomAccessInputStream.java
+++ b/src/main/java/loci/common/RandomAccessInputStream.java
@@ -117,6 +117,9 @@ public class RandomAccessInputStream extends InputStream implements DataInput, C
   /**
    * Constructs a hybrid RandomAccessFile/DataInputStream
    * around the given file.
+   *
+   * @param file a name that can be passed to {@link Location#getHandle(String)}
+   * @throws IOException if the name is invalid
    */
   public RandomAccessInputStream(String file) throws IOException {
     this(Location.getHandle(file), file);
@@ -125,13 +128,22 @@ public class RandomAccessInputStream extends InputStream implements DataInput, C
   /**
    * Constructs a hybrid RandomAccessFile/DataInputStream
    * around the given file.
+   *
+   * @param file a name that can be passed to {@link Location#getHandle(String)}
+   * @param bufferSize the size of the caching buffer in bytes
+   * @throws IOException if the name is invalid
    */
   public RandomAccessInputStream(String file, int bufferSize) throws IOException
   {
     this(Location.getHandle(file, false, true, bufferSize), file);
   }
 
-  /** Constructs a random access stream around the given handle. */
+  /**
+   * Constructs a random access stream around the given handle.
+   *
+   * @param handle the {@link IRandomAccess} to be wrapped
+   * @throws IOException if the handle is invalid
+   */
   public RandomAccessInputStream(IRandomAccess handle) throws IOException {
     this(handle, null);
   }
@@ -139,6 +151,10 @@ public class RandomAccessInputStream extends InputStream implements DataInput, C
   /**
    * Constructs a random access stream around the given handle,
    * and with the associated file path.
+   *
+   * @param handle the {@link IRandomAccess} to be wrapped
+   * @param file the name associated with the handle. Can be null.
+   * @throws IOException if the handle is invalid
    */
   public RandomAccessInputStream(IRandomAccess handle, String file)
     throws IOException
@@ -153,7 +169,12 @@ public class RandomAccessInputStream extends InputStream implements DataInput, C
     length = -1;
   }
 
-  /** Constructs a random access stream around the given byte array. */
+  /**
+   * Constructs a random access stream around the given byte array.
+   *
+   * @param array the byte array to be wrapped via {@link ByteArrayHandle}
+   * @throws IOException if the {@link ByteArrayHandle} cannot be created
+   */
   public RandomAccessInputStream(byte[] array) throws IOException {
     this(new ByteArrayHandle(array));
   }
@@ -163,18 +184,29 @@ public class RandomAccessInputStream extends InputStream implements DataInput, C
   /**
    * Sets the native encoding of the stream.
    *
+   * @param encoding the name of a standard charset to use when
+   *                 working with strings
    * @see loci.common.Constants#ENCODING
+   * @see java.nio.charset.Charset
    */
   public void setEncoding(String encoding) {
     this.encoding = encoding;
   }
 
-  /** Seeks to the given offset within the stream. */
+  /**
+   * Seeks to the given offset within the stream.
+   *
+   * @param pos the new byte offset
+   * @throws IOException if the seek fails
+   */
   public void seek(long pos) throws IOException {
     raf.seek(pos);
   }
 
-  /** Gets the number of bytes in the file. */
+  /**
+   * @return the number of bytes in the file.
+   * @throws IOException if the length cannot be retrieved
+   */
   public long length() throws IOException {
     return length < 0 ? raf.length() : length;
   }
@@ -186,6 +218,9 @@ public class RandomAccessInputStream extends InputStream implements DataInput, C
    * the file itself.
    *
    * Passing in a negative value will reset the length to the stream's real length.
+   *
+   * @param newLength the new stream length as defined above
+   * @throws IOException if the original stream length cannot be retrieved
    */
   public void setLength(long newLength) throws IOException {
     if (newLength < length()) {
@@ -193,7 +228,10 @@ public class RandomAccessInputStream extends InputStream implements DataInput, C
     }
   }
 
-  /** Gets the current (absolute) file pointer. */
+  /**
+   * @return the current (absolute) file pointer.
+   * @throws IOException if the current pointer cannot be retrieved
+   */
   public long getFilePointer() throws IOException {
     return raf.getFilePointer();
   }
@@ -210,14 +248,22 @@ public class RandomAccessInputStream extends InputStream implements DataInput, C
     markedPos = -1;
   }
 
-  /** Sets the endianness of the stream. */
+  /**
+   * Sets the endianness of the stream.
+   *
+   * @param little true if the stream ordering should be little-endian
+   */
   public void order(boolean little) {
     if (raf != null) {
       raf.setOrder(little ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
     }
   }
 
-  /** Gets the endianness of the stream. */
+  /**
+   * Gets the endianness of the stream.
+   *
+   * @return true if the stream ordering is little-endian
+   */
   public boolean isLittleEndian() {
     return raf.getOrder() == ByteOrder.LITTLE_ENDIAN;
   }
@@ -225,6 +271,11 @@ public class RandomAccessInputStream extends InputStream implements DataInput, C
   /**
    * Reads a string ending with one of the characters in the given string.
    *
+   * @param lastChars each character is a possible terminator
+   * @return The string from the initial position through the end of the
+   *   terminating sequence, or through the end of the stream if no
+   *   terminating sequence is found.
+   * @throws IOException If the maximum search length (512 MB) is exceeded.
    * @see #findString(String...)
    */
   public String readString(String lastChars) throws IOException {
@@ -244,6 +295,7 @@ public class RandomAccessInputStream extends InputStream implements DataInput, C
    * @return The string from the initial position through the end of the
    *   terminating sequence, or through the end of the stream if no
    *   terminating sequence is found.
+   * @throws IOException If the maximum search length (512 MB) is exceeded.
    */
   public String findString(String... terminators) throws IOException {
     return findString(true, DEFAULT_BLOCK_SIZE, terminators);
@@ -280,6 +332,7 @@ public class RandomAccessInputStream extends InputStream implements DataInput, C
    * @return The string from the initial position through the end of the
    *   terminating sequence, or through the end of the stream if no
    *   terminating sequence is found.
+   * @throws IOException If the maximum search length (512 MB) is exceeded.
    */
   public String findString(int blockSize, String... terminators)
     throws IOException
@@ -380,6 +433,8 @@ public class RandomAccessInputStream extends InputStream implements DataInput, C
    * Skips a number of bits in the BitBuffer.
    *
    * @param bits Number of bits to skip
+   * @throws IllegalArgumentException if bits is negative
+   * @throws IOException if an error occurs while skipping
    */
   public void skipBits(long bits) throws IOException {
     if (bits < 0) {
@@ -410,6 +465,8 @@ public class RandomAccessInputStream extends InputStream implements DataInput, C
    *
    * @param bitsToRead the number of bits to read from the bit buffer
    * @return the value of the bits read
+   * @throws IllegalArgumentException if bits is negative
+   * @throws IOException if an error occurs while skipping
    */
   public int readBits(int bitsToRead) throws IOException {
     if (bitsToRead < 0) {
@@ -509,6 +566,9 @@ public class RandomAccessInputStream extends InputStream implements DataInput, C
 
   /**
    * Read four input bytes and return an unsigned value.
+   *
+   * @return the next 4 bytes in the stream as a long
+   * @throws IOException if there is an error during reading
    */
   public long readUnsignedInt() throws IOException {
     return readInt() & 0xffffffffL;
@@ -521,7 +581,12 @@ public class RandomAccessInputStream extends InputStream implements DataInput, C
     return line.length() == 0 ? null : line;
   }
 
-  /** Read a string of arbitrary length, terminated by a null char. */
+  /**
+   * Read a string of arbitrary length, terminated by a null char.
+   *
+   * @return the shortest null-terminated string from the current pointer
+   * @throws IOException if there is an error during reading
+   */
   public String readCString() throws IOException {
     String line = findString("\0");
     return line.length() == 0 ? null : line;
@@ -534,6 +599,7 @@ public class RandomAccessInputStream extends InputStream implements DataInput, C
    * @param n The length of the array.
    * @return See above
    * @throws IOException Thrown if an error occurred while reading the data.
+   * @see #setEncoding(String)
    */
   public String readByteToString(int n) throws IOException {
     n = (int) Math.min(available(), n);
@@ -552,7 +618,14 @@ public class RandomAccessInputStream extends InputStream implements DataInput, C
     return new String(s.getBytes(encoding), encoding);
   }
 
-  /** Read a string of up to length n. */
+  /**
+   * Read a string of up to length n.
+   *
+   * @param n the number of bytes to read
+   * @return a string representing the read bytes, using the default encoding
+   * @throws IOException if an error occurred during reading
+   * @see #setEncoding(String)
+   */
   public String readString(int n) throws IOException {
     int avail = available();
     if (n > avail) n = avail;
@@ -615,13 +688,26 @@ public class RandomAccessInputStream extends InputStream implements DataInput, C
     return rtn;
   }
 
-  /** Read bytes from the stream into the given buffer. */
+  /**
+   * Read bytes from the stream into the given buffer.
+   *
+   * @param buf the {@link ByteBuffer} to fill. <code>buf.capacity()</code>
+   *            determines the number of bytes to read
+   * @return the number of bytes read
+   * @throws IOException if an error occurred during reading
+   */
   public int read(ByteBuffer buf) throws IOException {
     return raf.read(buf);
   }
 
   /**
    * Read n bytes from the stream into the given buffer at the specified offset.
+   *
+   * @param buf the {@link ByteBuffer} to fill
+   * @param offset the offset to the first byte in the buffer
+   * @param n the number of bytes to read
+   * @return the number of bytes actually read
+   * @throws IOException if an error occurred during reading
    */
   public int read(ByteBuffer buf, int offset, int n) throws IOException {
     return raf.read(buf, offset, n);

--- a/src/main/java/loci/common/RandomAccessOutputStream.java
+++ b/src/main/java/loci/common/RandomAccessOutputStream.java
@@ -72,51 +72,94 @@ public class RandomAccessOutputStream extends OutputStream implements DataOutput
     outputFile = handle;
   }
 
-  /** Constructs a random access stream around the given byte array. */
+  /**
+   * Constructs a random access stream around the given byte array.
+   *
+   * @param array the byte array to be written to
+   * @throws IOException if the array cannot be wrapped
+   *                     in a {@link ByteArrayHandle}
+   */
   public RandomAccessOutputStream(byte[] array) throws IOException {
     this(new ByteArrayHandle(array));
   }
 
   // -- RandomAccessOutputStream API methods --
 
-  /** Seeks to the given offset within the stream. */
+  /**
+   * Seeks to the given offset within the stream.
+   *
+   * @param pos the new offset within the stream
+   * @throws IOException is the seek is not successful
+   */
   public void seek(long pos) throws IOException {
     outputFile.seek(pos);
   }
 
-  /** Returns the current offset within the stream. */
+  /**
+   * @return the current offset within the stream.
+   * @throws IOException if the offset cannot be retrieved
+   */
   public long getFilePointer() throws IOException {
     return outputFile.getFilePointer();
   }
 
-  /** Returns the length of the file. */
+  /**
+   * @return the length of the file
+   * @throws IOException if the length cannot be retrieved
+   */
   public long length() throws IOException {
     return outputFile.length();
   }
 
-  /** Advances the current offset by the given number of bytes. */
+  /**
+   * Advances the current offset by the given number of bytes.
+   *
+   * @param skip the number of bytes to skip
+   * @throws IOException if the offset cannot be changed
+   */
   public void skipBytes(int skip) throws IOException {
     outputFile.seek(outputFile.getFilePointer() + skip);
   }
 
-  /** Sets the endianness of the stream. */
+  /**
+   * Sets the endianness of the stream.
+   *
+   * @param little true if the byte order of the stream is little-endian
+   */
   public void order(boolean little) {
     outputFile.setOrder(
       little ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
   }
 
-  /** Gets the endianness of the stream. */
+  /**
+   * Gets the endianness of the stream.
+   *
+   * @return true if the byte order of the stream is little-endian
+   */
   public boolean isLittleEndian() {
     return outputFile.getOrder() == ByteOrder.LITTLE_ENDIAN;
   }
 
-  /** Writes the given string followed by a newline character. */
+  /**
+   * Writes the given string followed by a newline character.
+   *
+   * @param s the line of text to be written.  A newline does not
+   *          need to be appended, as this method automatically writes
+   *          a newline character.
+   * @throws IOException if writing is not possible
+   */
   public void writeLine(String s) throws IOException {
     writeBytes(s);
     writeBytes("\n");
   }
 
-  /** Writes the given value using the given number of bits. */
+  /**
+   * Writes the given value using the given number of bits.
+   *
+   * @param value int value to be written
+   * @param numBits exact number of bits to be written
+   * @throws IOException if writing fails for any reason
+   */
   public void writeBits(int value, int numBits) throws IOException {
     if (numBits <= 0) {
       return;
@@ -139,8 +182,13 @@ public class RandomAccessOutputStream extends OutputStream implements DataOutput
   /**
    * Writes the bits represented by a bit string to the buffer.
    *
+   * @param bitString a string of '0' and/or '1' characters representing
+   *                  bits to be written. Each character in the string results
+   *                  in a call to {@link #writeBits(int, int)}
+   *                  that writes 1 bit.
    * @throws IllegalArgumentException If any characters other than
    *   '0' and '1' appear in the string.
+   * @throws IOException if writing fails for any other reason
    */
   public void writeBits(String bitString) throws IOException {
     if (bitString == null) {

--- a/src/main/java/loci/common/ReflectedUniverse.java
+++ b/src/main/java/loci/common/ReflectedUniverse.java
@@ -80,12 +80,22 @@ public class ReflectedUniverse {
    * Constructs a new reflected universe, with the given URLs
    * representing additional search paths for imported classes
    * (in addition to the CLASSPATH).
+   *
+   * @param urls array of URLs to search for additional classes.
+   *             Each URL is typically a JAR file that is not on
+   *             the CLASSPATH.
    */
   public ReflectedUniverse(URL[] urls) {
     this(urls == null ? null : new URLClassLoader(urls));
   }
 
-  /** Constructs a new reflected universe that uses the given class loader. */
+  /**
+   * Constructs a new reflected universe that uses the given class loader.
+   *
+   * @param loader the ClassLoader to use in this universe.
+   *               If null, the default ClassLoader for the ReflectedUniverse
+   *               class will be used.
+   */
   public ReflectedUniverse(ClassLoader loader) {
     variables = new HashMap<String, Object>();
     this.loader = loader == null ? getClass().getClassLoader() : loader;
@@ -96,6 +106,10 @@ public class ReflectedUniverse {
   /**
    * Returns whether the given object is compatible with the
    * specified class for the purposes of reflection.
+   *
+   * @param c the base class
+   * @param o the object that needs type checking
+   * @return true if the object is an instance of the base class
    */
   public static boolean isInstance(Class<?> c, Object o) {
     return (o == null || c.isInstance(o) ||
@@ -140,6 +154,13 @@ public class ReflectedUniverse {
    *     </ol>
    *   </li>
    * </ul>
+   *
+   * @param command the command to be executed (see examples above)
+   * @return the result of executing the command. For import statements,
+   *         the return value is null. Otherwise, the return value of
+   *         the invoked method or the value assigned to a variable
+   *         is returned (depending upon the command).
+   * @throws ReflectException if the command is invalid or fails to execute
    */
   public Object exec(String command) throws ReflectException {
     command = command.trim();
@@ -322,48 +343,93 @@ public class ReflectedUniverse {
     return result;
   }
 
-  /** Registers a variable in the universe. */
+  /**
+   * Registers a variable in the universe.
+   *
+   * @param varName the name of the variable to assign
+   * @param obj the value to assign to the variable
+   */
   public void setVar(String varName, Object obj) {
     if (obj == null) variables.remove(varName);
     else variables.put(varName, obj);
   }
 
-  /** Registers a variable of primitive type boolean in the universe. */
+  /**
+   * Registers a variable of primitive type boolean in the universe.
+   *
+   * @param varName the name of the variable to assign
+   * @param b the boolean value to assign to the variable
+   */
   public void setVar(String varName, boolean b) {
     setVar(varName, new Boolean(b));
   }
 
-  /** Registers a variable of primitive type byte in the universe. */
+  /**
+   * Registers a variable of primitive type byte in the universe.
+   *
+   * @param varName the name of the variable to assign
+   * @param b the byte value to assign to the variable
+   */
   public void setVar(String varName, byte b) {
     setVar(varName, new Byte(b));
   }
 
-  /** Registers a variable of primitive type char in the universe. */
+  /**
+   * Registers a variable of primitive type char in the universe.
+   *
+   * @param varName the name of the variable to assign
+   * @param c the char value to assign to the variable
+   */
   public void setVar(String varName, char c) {
     setVar(varName, Character.valueOf(c));
   }
 
-  /** Registers a variable of primitive type double in the universe. */
+  /**
+   * Registers a variable of primitive type double in the universe.
+   *
+   * @param varName the name of the variable to assign
+   * @param d the double value to assign to the variable
+   */
   public void setVar(String varName, double d) {
     setVar(varName, new Double(d));
   }
 
-  /** Registers a variable of primitive type float in the universe. */
+  /**
+   * Registers a variable of primitive type float in the universe.
+   *
+   * @param varName the name of the variable to assign
+   * @param f the float value to assign to the variable
+   */
   public void setVar(String varName, float f) {
     setVar(varName, new Float(f));
   }
 
-  /** Registers a variable of primitive type int in the universe. */
+  /**
+   * Registers a variable of primitive type int in the universe.
+   *
+   * @param varName the name of the variable to assign
+   * @param i the int value to assign to the variable
+   */
   public void setVar(String varName, int i) {
     setVar(varName, Integer.valueOf(i));
   }
 
-  /** Registers a variable of primitive type long in the universe. */
+  /**
+   * Registers a variable of primitive type long in the universe.
+   *
+   * @param varName the name of the variable to assign
+   * @param l the long value to assign to the variable
+   */
   public void setVar(String varName, long l) {
     setVar(varName, Long.valueOf(l));
   }
 
-  /** Registers a variable of primitive type short in the universe. */
+  /**
+   * Registers a variable of primitive type short in the universe.
+   *
+   * @param varName the name of the variable to assign
+   * @param s the short value to assign to the variable
+   */
   public void setVar(String varName, short s) {
     setVar(varName, Short.valueOf(s));
   }
@@ -371,6 +437,10 @@ public class ReflectedUniverse {
   /**
    * Returns the value of a variable or field in the universe.
    * Primitive types will be wrapped in their Java Object wrapper classes.
+   *
+   * @param varName the name of the variable to retrieve
+   * @return the current value of the variable
+   * @throws ReflectException if the variable name or value is invalid
    */
   public Object getVar(String varName) throws ReflectException {
     if (varName.equals("null")) {
@@ -439,12 +509,20 @@ public class ReflectedUniverse {
     return var;
   }
 
-  /** Sets whether access modifiers (protected, private, etc.) are ignored. */
+  /**
+   * Sets whether access modifiers (protected, private, etc.) are ignored.
+   *
+   * @param ignore true if access modifiers should be ignored
+   */
   public void setAccessibilityIgnored(boolean ignore) {
     force = ignore;
   }
 
-  /** Gets whether access modifiers (protected, private, etc.) are ignored. */
+  /**
+   * Gets whether access modifiers (protected, private, etc.) are ignored.
+   *
+   * @return true if access modifiers are currently ignored
+   */
   public boolean isAccessibilityIgnored() {
     return force;
   }
@@ -453,6 +531,9 @@ public class ReflectedUniverse {
 
   /**
    * Allows exploration of a reflected universe in an interactive environment.
+   *
+   * @param args if non-empty, access modifiers will be ignored
+   * @throws IOException if there is an error reading from stdin
    */
   public static void main(String[] args) throws IOException {
     ReflectedUniverse r = new ReflectedUniverse();

--- a/src/main/java/loci/common/Region.java
+++ b/src/main/java/loci/common/Region.java
@@ -60,7 +60,11 @@ public class Region {
 
   // -- Region API --
 
-  /** Returns true if this region intersects the given region. */
+  /**
+   * @param r the region to check for intersection
+   * @return true if this region intersects the given region
+   * @see java.awt.Rectangle#intersects(java.awt.Rectangle)
+   */
   public boolean intersects(Region r) {
     int tw = this.width;
     int th = this.height;
@@ -86,6 +90,11 @@ public class Region {
    * Returns a Region representing the intersection of this Region with the
    * given Region.  If the two Regions do not intersect, the result is an
    * empty Region.
+   *
+   * @param r the region for which to calculate an intersection (or overlap)
+   * @return a Region representing the intersection (overlap) of the two Regions.
+   *         If the two Regions have no common area, then the width and/or height
+   *         of the returned Region will be 0.  null is never returned.
    */
   public Region intersection(Region r) {
     int x = Math.max(this.x, r.x);
@@ -102,6 +111,10 @@ public class Region {
   /**
    * Returns true if the point specified by the given X and Y coordinates
    * is contained within this region.
+   *
+   * @param xc the integer X coordinate of a point
+   * @param yc the integer Y coordinate of a point
+   * @return true if this Region encloses the given point
    */
   public boolean containsPoint(int xc, int yc) {
     return intersects(new Region(xc, yc, 1, 1));

--- a/src/main/java/loci/common/StatusEvent.java
+++ b/src/main/java/loci/common/StatusEvent.java
@@ -53,22 +53,46 @@ public class StatusEvent {
 
   // -- Constructor --
 
-  /** Constructs a status event. */
+  /**
+   * Constructs a non-warning status event.
+   * The initial progress and maximum progress are set to -1.
+   *
+   * @param message the initial status message
+   */
   public StatusEvent(String message) {
     this(-1, -1, message);
   }
 
-  /** Constructs a status event. */
+  /**
+   * Constructs a status event.
+   * The initial progress and maximum progress are set to -1.
+   *
+   * @param message the initial status message
+   * @param warn true if this is a warning event
+   */
   public StatusEvent(String message, boolean warn) {
     this(-1, -1, message, warn);
   }
 
-  /** Constructs a status event. */
+  /**
+   * Constructs a non-warning status event.
+   *
+   * @param progress the current progress value
+   * @param maximum the maximum progress value
+   * @param message the initial status message
+   */
   public StatusEvent(int progress, int maximum, String message) {
     this(progress, maximum, message, false);
   }
 
-  /** Constructs a status event. */
+  /**
+   * Constructs a status event.
+   *
+   * @param progress the current progress value
+   * @param maximum the maximum progress value
+   * @param message the initial status message
+   * @param warn true if this is a warning event
+   */
   public StatusEvent(int progress, int maximum, String message, boolean warn) {
     this.progress = progress;
     this.maximum = maximum;
@@ -78,22 +102,30 @@ public class StatusEvent {
 
   // -- StatusEvent API methods --
 
-  /** Gets progress value. Returns -1 if progress is unknown. */
+  /**
+   * @return the progress value. Returns -1 if progress is unknown.
+   */
   public int getProgressValue() {
     return progress;
   }
 
-  /** Gets progress maximum. Returns -1 if progress is unknown. */
+  /**
+   * @return progress maximum. Returns -1 if progress is unknown.
+   */
   public int getProgressMaximum() {
     return maximum;
   }
 
-  /** Gets status message. */
+  /**
+   * @return status message.
+   */
   public String getStatusMessage() {
     return status;
   }
 
-  /** Returns whether or not this is a warning event. */
+  /**
+   * @return true if this is a warning event.
+   */
   public boolean isWarning() {
     return warning;
   }

--- a/src/main/java/loci/common/StatusListener.java
+++ b/src/main/java/loci/common/StatusListener.java
@@ -39,7 +39,11 @@ import java.util.EventListener;
  */
 public interface StatusListener extends EventListener {
 
-  /** Called when status is updated. */
+  /**
+   * Called when status is updated.
+   *
+   * @param e the event representing the current status
+   */
   void statusUpdated(StatusEvent e);
 
 }

--- a/src/main/java/loci/common/StreamHandle.java
+++ b/src/main/java/loci/common/StreamHandle.java
@@ -459,6 +459,8 @@ public abstract class StreamHandle implements IRandomAccess {
    * Close and reopen the stream; the stream pointer and mark should be
    * reset to 0.  This method is called if we need to seek backwards within
    * the stream.
+   *
+   * @throws IOException if the stream cannot be reset
    */
   protected abstract void resetStream() throws IOException;
 

--- a/src/main/java/loci/common/URLHandle.java
+++ b/src/main/java/loci/common/URLHandle.java
@@ -62,6 +62,9 @@ public class URLHandle extends StreamHandle {
 
   /**
    * Constructs a new URLHandle using the given URL.
+   *
+   * @param url the fully qualified URL path
+   * @throws IOException if the URL is invalid or unreadable
    */
   public URLHandle(String url) throws IOException {
     if (!url.startsWith("http") && !url.startsWith("file:")) {

--- a/src/main/java/loci/common/ZipHandle.java
+++ b/src/main/java/loci/common/ZipHandle.java
@@ -99,7 +99,11 @@ public class ZipHandle extends StreamHandle {
    * Constructs a new ZipHandle corresponding to the given entry of the
    * specified Zip file.
    *
+   * @param file a name that can be passed to
+   *        {@link Location#getHandle(String, boolean, boolean)}
+   * @param entry the specific entry in the Zip file to be opened
    * @throws HandleException if the given file is not a Zip file.
+   * @see ZipEntry
    */
   public ZipHandle(String file, ZipEntry entry) throws IOException {
     super();
@@ -120,7 +124,12 @@ public class ZipHandle extends StreamHandle {
 
   // -- ZipHandle API methods --
 
-  /** Returns true if the given filename is a Zip file. */
+  /**
+   * @param file a name that can be passed to
+   *        {@link Location#getHandle(String, boolean, boolean)}
+   * @return true if the given filename is a Zip file.
+   * @throws IOException if the file cannot be read
+   */
   public static boolean isZipFile(String file) throws IOException {
     if (!file.toLowerCase().endsWith(".zip")) return false;
 
@@ -133,17 +142,23 @@ public class ZipHandle extends StreamHandle {
     return new String(b, Constants.ENCODING).equals("PK");
   }
 
-  /** Get the name of the backing Zip entry. */
+  /**
+   * @return the name of the backing Zip entry.
+   */
   public String getEntryName() {
     return entryName;
   }
 
-  /** Returns the DataInputStream corresponding to the backing Zip entry. */
+  /**
+   * @return the DataInputStream corresponding to the backing Zip entry.
+   */
   public DataInputStream getInputStream() {
     return stream;
   }
 
-  /** Returns the number of entries. */
+  /**
+   * @return the number of entries.
+   */
   public int getEntryCount() {
     return entryCount;
   }

--- a/src/main/java/loci/common/services/DependencyException.java
+++ b/src/main/java/loci/common/services/DependencyException.java
@@ -36,7 +36,7 @@ package loci.common.services;
  * Exception thrown when there is an object instantiation error or error
  * processing dependencies.
  *
- * @author Chris Allan <callan at blackcat dot ca>
+ * @author Chris Allan (callan at blackcat dot ca)
  */
 public class DependencyException extends Exception
 {

--- a/src/main/java/loci/common/services/ServiceException.java
+++ b/src/main/java/loci/common/services/ServiceException.java
@@ -36,7 +36,7 @@ package loci.common.services;
  * Exception thrown when there is an error within a given service. That could
  * not be handled.
  *
- * @author Chris Allan <callan at blackcat dot ca>
+ * @author Chris Allan (callan at blackcat dot ca)
  */
 public class ServiceException extends Exception
 {

--- a/src/main/java/loci/common/services/ServiceFactory.java
+++ b/src/main/java/loci/common/services/ServiceFactory.java
@@ -141,6 +141,7 @@ public class ServiceFactory {
 
   /**
    * Retrieves an instance of a given service.
+   * @param <T> generic service type
    * @param type Interface type of the service.
    * @return A newly instantiated service.
    * @throws DependencyException If there is an error instantiating the

--- a/src/main/java/loci/common/xml/XMLTools.java
+++ b/src/main/java/loci/common/xml/XMLTools.java
@@ -154,6 +154,8 @@ public final class XMLTools {
   /**
    * Creates a new {@link DocumentBuilder} via {@link DocumentBuilderFactory}
    * or logs and throws a {@link RuntimeException}.
+   *
+   * @return the default {@link DocumentBuilder} instance
    */
   public static DocumentBuilder createBuilder() {
     try {
@@ -168,12 +170,22 @@ public final class XMLTools {
   /**
    * Calls {@link DocumentBuilder#newDocument()} on a
    * {@link #createBuilder() new builder}.
+   *
+   * @return an empty {@link Document}
    */
   public static Document createDocument() {
     return createBuilder().newDocument();
   }
 
-  /** Parses a DOM from the given XML file on disk. */
+  /**
+   * Parses a DOM from the given XML file on disk.
+   *
+   * @param file a file on disk that contains XML
+   * @return a {@link Document} reflecting the contents of the file
+   * @throws ParserConfigurationException if the XML parser cannot be created
+   * @throws SAXException if there is an error parsing the XML
+   * @throws IOException if there is an error reading from the file
+   */
   public static Document parseDOM(File file)
     throws ParserConfigurationException, SAXException, IOException
   {
@@ -186,7 +198,15 @@ public final class XMLTools {
     }
   }
 
-  /** Parses a DOM from the given XML string. */
+  /**
+   * Parses a DOM from the given XML string.
+   *
+   * @param xml XML data
+   * @return a {@link Document} reflecting the XML string
+   * @throws ParserConfigurationException if the XML parser cannot be created
+   * @throws SAXException if there is an error parsing the XML
+   * @throws IOException if there is an error reading from the file
+   */
   public static Document parseDOM(String xml)
     throws ParserConfigurationException, SAXException, IOException
   {
@@ -200,7 +220,15 @@ public final class XMLTools {
     }
   }
 
-  /** Parses a DOM from the given XML input stream. */
+  /**
+   * Parses a DOM from the given XML input stream.
+   *
+   * @param is the {@link InputStream} containing XML
+   * @return a {@link Document} representing the XML
+   * @throws ParserConfigurationException if the XML parser cannot be created
+   * @throws SAXException if there is an error parsing the XML
+   * @throws IOException if there is an error reading from the stream
+   */
   public static Document parseDOM(InputStream is)
     throws ParserConfigurationException, SAXException, IOException
   {
@@ -215,7 +243,15 @@ public final class XMLTools {
     return db.parse(in);
   }
 
-  /** Converts the given DOM back to a string. */
+  /**
+   * Converts the given DOM back to a string.
+   *
+   * @param doc the {@link Document} representing the XML
+   * @return a string representation of the XML
+   * @throws TransformerConfigurationException if there is an error
+   *         initializing the conversion
+   * @throws TransformerException if there is an error during writing
+   */
   public static String getXML(Document doc)
     throws TransformerConfigurationException, TransformerException
   {
@@ -228,6 +264,8 @@ public final class XMLTools {
   /**
    * Dumps the given OME-XML DOM tree to a string.
    * @param schemaLocation if null, no xmlns attribute will be added.
+   * @param doc the {@link Document} representing the XML to be written
+   * @param r the {@link Element} to use for adding the schema location
    * @return OME-XML as a string.
    */
   public static String dumpXML(String schemaLocation, Document doc, Element r) {
@@ -237,6 +275,10 @@ public final class XMLTools {
   /**
    * Dumps the given OME-XML DOM tree to a string.
    * @param schemaLocation if null, no xmlns attribute will be added.
+   * @param doc the {@link Document} representing the XML to be written
+   * @param r the {@link Element} to use for adding the schema location
+   * @param includeXMLDeclaration false if the XML declaration should
+   *        be omitted, see {@link OutputKeys#OMIT_XML_DECLARATION}
    * @return OME-XML as a string.
    */
   public static String dumpXML(String schemaLocation, Document doc, Element r,
@@ -263,7 +305,15 @@ public final class XMLTools {
 
   // -- Filtering --
 
-  /** Escape special characters. */
+  /**
+   * Escape special characters.
+   * Replaces quotes, ampersands, and angle brackets
+   * with the escaped equivalent.
+   *
+   * @param s input string containing characters to escape
+   * @return copy of the input string with characters escaped
+   *         as described above
+   */
   public static String escapeXML(String s) {
     StringBuffer sb = new StringBuffer();
 
@@ -293,7 +343,13 @@ public final class XMLTools {
     return sb.toString();
   }
 
-  /** Remove invalid characters from an XML string. */
+  /**
+   * Remove invalid characters from an XML string.
+   *
+   * @param s the input string from which to remove invalid characters
+   * @return a copy of the input string with CR, LF, tab, and control
+   *         characters replaced by a single space
+   */
   public static String sanitizeXML(String s) {
     final char[] c = s.toCharArray();
     for (int i=0; i<s.length(); i++) {
@@ -308,12 +364,27 @@ public final class XMLTools {
     return new String(c);
   }
 
-  /** Indents XML to be more readable. */
+  /**
+   * Indents XML to be more readable.
+   * Uses 3 spaces to indent, and may indent CDATA.
+   *
+   * @param xml the XML string to format
+   * @return the formatted XML string
+   * @see #indentXML(String, int, boolean)
+   */
   public static String indentXML(String xml) {
     return indentXML(xml, 3, false);
   }
 
-  /** Indents XML by the given spacing to be more readable. */
+  /**
+   * Indents XML by the given spacing to be more readable.
+   * CDATA may be indented.
+   *
+   * @param xml the XML string to format
+   * @param spacing the number of spaces by which to indent
+   * @return the formatted XML string
+   * @see #indentXML(String, int, boolean)
+   */
   public static String indentXML(String xml, int spacing) {
     return indentXML(xml, spacing, false);
   }
@@ -321,6 +392,13 @@ public final class XMLTools {
   /**
    * Indents XML to be more readable, avoiding any whitespace
    * injection into CDATA if the preserveCData flag is set.
+   * Uses 3 spaces to indent.
+   *
+   * @param xml the XML string to format
+   * @param preserveCData true if CDATA nodes should be preserved
+   *                      with no indenting
+   * @return the formatted XML string
+   * @see #indentXML(String, int, boolean)
    */
   public static String indentXML(String xml, boolean preserveCData) {
     return indentXML(xml, 3, preserveCData);
@@ -329,6 +407,12 @@ public final class XMLTools {
   /**
    * Indents XML by the given spacing to be more readable, avoiding any
    * whitespace injection into CDATA if the preserveCData flag is set.
+   *
+   * @param xml the XML string to format
+   * @param spacing the number of spaces by which to indent
+   * @param preserveCData true if CDATA nodes should be preserved
+   *                      with no indenting
+   * @return the formatted XML string
    */
   public static String indentXML(String xml, int spacing,
     boolean preserveCData)
@@ -391,7 +475,14 @@ public final class XMLTools {
 
   // -- Parsing --
 
-  /** Parses the given XML string into a list of key/value pairs. */
+  /**
+   * Parses the given XML string into a list of key/value pairs.
+   *
+   * @param xml the {@link InputStream} representing the XML
+   * @return a hashtable of key/value pairs representing the XML
+   * @throws IOException if there is an error during parsing
+   * @see MetadataHandler
+   */
   public static Hashtable<String, String> parseXML(String xml)
     throws IOException
   {
@@ -402,6 +493,10 @@ public final class XMLTools {
 
   /**
    * Parses the given XML string using the specified XML handler.
+   *
+   * @param xml the string representing the XML
+   * @param handler the {@link DefaultHandler} to use for parsing
+   * @throws IOException if there is an error during parsing
    */
   public static void parseXML(String xml, DefaultHandler handler)
     throws IOException
@@ -413,6 +508,10 @@ public final class XMLTools {
    * Parses the XML contained in the given input stream into
    * using the specified XML handler.
    * Be very careful, as 'stream' <b>will</b> be closed by the SAX parser.
+   *
+   * @param stream the {@link RandomAccessInputStream} representing the XML
+   * @param handler the {@link DefaultHandler} to use for parsing
+   * @throws IOException if there is an error during parsing
    */
   public static void parseXML(RandomAccessInputStream stream,
     DefaultHandler handler) throws IOException
@@ -423,6 +522,10 @@ public final class XMLTools {
   /**
    * Parses the XML contained in the given byte array into
    * using the specified XML handler.
+   *
+   * @param xml the byte array representing the XML
+   * @param handler the {@link DefaultHandler} to use for parsing
+   * @throws IOException if there is an error during parsing
    */
   public static void parseXML(byte[] xml, DefaultHandler handler)
     throws IOException
@@ -433,6 +536,10 @@ public final class XMLTools {
   /**
    * Parses the XML contained in the given InputStream using the
    * specified XML handler.
+   *
+   * @param xml the {@link InputStream} representing the XML
+   * @param handler the {@link DefaultHandler} to use for parsing
+   * @throws IOException if there is an error during parsing
    */
   public static void parseXML(InputStream xml, DefaultHandler handler)
     throws IOException
@@ -457,14 +564,28 @@ public final class XMLTools {
 
   // -- I/O --
 
-  /** Writes the specified DOM to the given output stream. */
+  /**
+   * Writes the specified DOM to the given output stream.
+   *
+   * @param os the {@link OutputStream} to which XML should be written
+   * @param doc the {@link Document} representing the XML to write
+   * @throws TransformerException if there is an error during writing
+   */
   public static void writeXML(OutputStream os, Document doc)
     throws TransformerException
   {
     writeXML(os, doc, true);
   }
 
-  /** Writes the specified DOM to the given output stream. */
+  /**
+   * Writes the specified DOM to the given output stream.
+   *
+   * @param os the {@link OutputStream} to which XML should be written
+   * @param doc the {@link Document} representing the XML to write
+   * @param includeXMLDeclaration false if the XML declaration should
+   *        be omitted, see {@link OutputKeys#OMIT_XML_DECLARATION}
+   * @throws TransformerException if there is an error during writing
+   */
   public static void writeXML(OutputStream os, Document doc,
     boolean includeXMLDeclaration)
     throws TransformerException
@@ -472,7 +593,15 @@ public final class XMLTools {
     writeXML(new StreamResult(os), doc, includeXMLDeclaration);
   }
 
-  /** Writes the specified DOM to the given stream. */
+  /**
+   * Writes the specified DOM to the given stream.
+   *
+   * @param output the {@link Result} to which XML should be written
+   * @param doc the {@link Document} representing the XML to write
+   * @param includeXMLDeclaration false if the XML declaration should
+   *        be omitted, see {@link OutputKeys#OMIT_XML_DECLARATION}
+   * @throws TransformerException if there is an error during writing
+   */
   public static void writeXML(Result output, Document doc,
     boolean includeXMLDeclaration)
     throws TransformerException
@@ -487,7 +616,13 @@ public final class XMLTools {
 
   // -- XSLT --
 
-  /** Gets an XSLT template from the given resource location. */
+  /**
+   * Gets an XSLT template from the given resource location.
+   *
+   * @param resourcePath the name of the stylesheet resource
+   * @param sourceClass the class to use when searching for the resource
+   * @return a {@link Templates} object representing the stylesheet
+   */
   public static Templates getStylesheet(String resourcePath,
     Class<?> sourceClass)
   {
@@ -524,7 +659,13 @@ public final class XMLTools {
     return null;
   }
 
-  /** Replaces NS:tag with NS_tag for undeclared namespaces */
+  /**
+   * Replaces NS:tag with NS_tag for undeclared namespaces
+   *
+   * @param xml the XML string whose namespaces need to be replaced
+   * @return a copy of the input string with NS:tag replaced by NS_tag
+   *         for any undeclared namespaces
+   */
   public static String avoidUndeclaredNamespaces(String xml) {
     int gt = xml.indexOf('>');
     if (gt > 0 && xml.startsWith("<?xml ")) {
@@ -569,7 +710,15 @@ public final class XMLTools {
     return xml;
   }
 
-  /** Transforms the given XML string using the specified XSLT stylesheet. */
+  /**
+   * Transforms the given XML string using the specified XSLT stylesheet.
+   *
+   * @param xml the XML string to be transformed
+   * @param xslt the {@link Templates} object representing an XSLT stylesheet
+   * @return the XML string that results from applying the stylesheet
+   * @throws IOException if there is an error parsing the XML
+   * @see #getStylesheet(String, Class)
+   */
   public static String transformXML(String xml, Templates xslt)
     throws IOException
   {
@@ -577,7 +726,16 @@ public final class XMLTools {
     return transformXML(new StreamSource(new StringReader(xml)), xslt);
   }
 
-  /** Transforms the given XML data using the specified XSLT stylesheet. */
+  /**
+   * Transforms the given XML data using the specified XSLT stylesheet.
+   *
+   * @param xmlSource the {@link Source} object representing
+   *                  the XML to be transformed
+   * @param xslt the {@link Templates} object representing an XSLT stylesheet
+   * @return the XML string that results from applying the stylesheet
+   * @throws IOException if there is an error parsing the XML
+   * @see #getStylesheet(String, Class)
+   */
   public static String transformXML(Source xmlSource, Templates xslt)
     throws IOException
   {


### PR DESCRIPTION
See https://github.com/ome/ome-common-java/issues/2

Without this PR, ```mvn javadoc:javadoc``` does not fail, but reports many warnings.  With this PR, the same command should continue to succeed and not produce any warnings.

There should not be any code changes here, only Javadoc changes.  I have not enabled ```mvn javadoc:javadoc``` in Travis, but could do so here if desired.