### PR TITLE
provide skipBytes(long) methods

### DIFF
--- a/src/main/java/loci/common/ByteArrayHandle.java
+++ b/src/main/java/loci/common/ByteArrayHandle.java
@@ -379,12 +379,19 @@ public class ByteArrayHandle extends AbstractNIOHandle {
   /* @see java.io.DataInput.skipBytes(int) */
   @Override
   public int skipBytes(int n) throws IOException {
-    int skipped = (int) Math.min(n, length() - getFilePointer());
-    if (skipped < 0) {
+    return (int) skipBytes((long) n);
+  }
+
+  /* @see #skipBytes(int) */
+  @Override
+  public long skipBytes(long n) throws IOException {
+    final long currentPosition = getFilePointer();
+    n = Math.min(n, length() - currentPosition);
+    if (n <= 0) {
       return 0;
     }
-    seek(getFilePointer() + skipped);
-    return skipped;
+    seek(currentPosition + n);
+    return n;
   }
 
   // -- DataOutput API methods --

--- a/src/main/java/loci/common/FileHandle.java
+++ b/src/main/java/loci/common/FileHandle.java
@@ -244,6 +244,22 @@ public class FileHandle implements IRandomAccess {
     return raf.skipBytes(n);
   }
 
+  /* @see #skipBytes(int) */
+  @Override
+  public long skipBytes(long n) throws IOException {
+    if (n < 1) {
+      return 0;
+    }
+    final long currentPosition = getFilePointer();
+    n = Math.min(n, length() - currentPosition);
+    if (n <= Integer.MAX_VALUE) {
+      /* use standard library if possible */
+      return skipBytes((int) n);
+    }
+    seek(currentPosition + n);
+    return n;
+  }
+
   // -- DataOutput API metthods --
 
   /* @see java.io.DataOutput.write(byte[]) */

--- a/src/main/java/loci/common/IRandomAccess.java
+++ b/src/main/java/loci/common/IRandomAccess.java
@@ -143,6 +143,14 @@ public interface IRandomAccess extends DataInput, DataOutput {
   void seek(long pos) throws IOException;
 
   /**
+   * A {@code long} variant of {@link #skipBytes(int)}.
+   * @param n the number of bytes to skip
+   * @return the number of bytes skipped
+   * @throws IOException if the operation failed
+   */
+  long skipBytes(long n) throws IOException;
+
+  /**
    * Writes up to buffer.capacity() bytes of data from the given
    * ByteBuffer to this stream.
    *

--- a/src/main/java/loci/common/NIOFileHandle.java
+++ b/src/main/java/loci/common/NIOFileHandle.java
@@ -469,6 +469,12 @@ public class NIOFileHandle extends AbstractNIOHandle {
   /* @see java.io.DataInput.skipBytes(int) */
   @Override
   public int skipBytes(int n) throws IOException {
+    return (int) skipBytes((long) n);
+  }
+
+  /* @see #skipBytes(int) */
+  @Override
+  public long skipBytes(long n) throws IOException {
     if (n < 1) {
       return 0;
     }
@@ -476,7 +482,7 @@ public class NIOFileHandle extends AbstractNIOHandle {
     long newPosition = oldPosition + Math.min(n, length());
 
     buffer(newPosition, 0);
-    return (int) (position - oldPosition);
+    return position - oldPosition;
   }
 
   // -- DataOutput API methods --

--- a/src/main/java/loci/common/RandomAccessInputStream.java
+++ b/src/main/java/loci/common/RandomAccessInputStream.java
@@ -442,7 +442,7 @@ public class RandomAccessInputStream extends InputStream implements DataInput, C
     }
 
     bits += currentBit;
-    int bytesToSkip = (int) (bits / 8);
+    final long bytesToSkip = bits / 8;
     currentBit = (int) (bits % 8);
     if (bytesToSkip > 0) {
       skipBytes(bytesToSkip);

--- a/src/main/java/loci/common/RandomAccessInputStream.java
+++ b/src/main/java/loci/common/RandomAccessInputStream.java
@@ -670,6 +670,11 @@ public class RandomAccessInputStream extends InputStream implements DataInput, C
     return raf.skipBytes(n);
   }
 
+  /** Skip n bytes within the stream. */
+  public long skipBytes(long n) throws IOException {
+    return raf.skipBytes(n);
+  }
+
   /** Read bytes from the stream into the given array. */
   @Override
   public int read(byte[] array) throws IOException {

--- a/src/main/java/loci/common/RandomAccessOutputStream.java
+++ b/src/main/java/loci/common/RandomAccessOutputStream.java
@@ -39,6 +39,8 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import com.google.common.math.LongMath;
+
 /**
  * RandomAccessOutputStream provides methods for writing to files and
  * byte arrays.
@@ -118,7 +120,16 @@ public class RandomAccessOutputStream extends OutputStream implements DataOutput
    * @throws IOException if the offset cannot be changed
    */
   public void skipBytes(int skip) throws IOException {
-    outputFile.seek(outputFile.getFilePointer() + skip);
+    final long currentPosition = outputFile.getFilePointer();
+    final long newPosition;
+    try {
+      /* in Java 8 can instead use addExact */
+      newPosition = LongMath.checkedAdd(currentPosition, skip);
+    } catch (ArithmeticException ae) {
+      /* translate to expected checked exception */
+      throw new IOException("seek is out of range", ae);
+    }
+    outputFile.seek(newPosition);
   }
 
   /**

--- a/src/main/java/loci/common/StreamHandle.java
+++ b/src/main/java/loci/common/StreamHandle.java
@@ -306,9 +306,15 @@ public abstract class StreamHandle implements IRandomAccess {
   /* @see java.io.DataInput#skipBytes(int) */
   @Override
   public int skipBytes(int n) throws IOException {
-    int skipped = 0;
+    return (int) skipBytes((long) n);
+  }
+
+  /* @see #skipBytes(int) */
+  @Override
+  public long skipBytes(long n) throws IOException {
+    long skipped = 0;
     try {
-      for (int i=0; i<n; i++) {
+      for (long i=0; i<n; i++) {
         if (readUnsignedByte() != -1) skipped++;
         markManager();
       }

--- a/src/main/java/loci/common/URLHandle.java
+++ b/src/main/java/loci/common/URLHandle.java
@@ -105,12 +105,9 @@ public class URLHandle extends StreamHandle {
 
   /** Skip over the given number of bytes. */
   private void skip(long bytes) throws IOException {
-    while (bytes >= Integer.MAX_VALUE) {
-      bytes -= skipBytes(Integer.MAX_VALUE);
-    }
-    int skipped = skipBytes((int) bytes);
+    long skipped = 0;
     while (skipped < bytes) {
-      int n = skipBytes((int) (bytes - skipped));
+      final long n = skipBytes(bytes - skipped);
       if (n == 0) break;
       skipped += n;
     }


### PR DESCRIPTION
Provides `skipBytes(long)` methods alongside existing `skipBytes(int)` methods to ease support of larger data. Testing could include reverting https://github.com/openmicroscopy/bioformats/pull/3157 and attempting a different fix. This PR could reasonably be considered to be breaking.