### PR TITLE
Attempt to check for incorrect length after RandomAccessFile.setLength

### DIFF
--- a/src/main/java/loci/common/NIOFileHandle.java
+++ b/src/main/java/loci/common/NIOFileHandle.java
@@ -227,6 +227,16 @@ public class NIOFileHandle extends AbstractNIOHandle {
   public void setLength(long length) throws IOException {
     if (raf.length() < length) {
       raf.setLength(length);
+      if (raf.length() != length) {
+        // something went wrong with setting the length
+        // use writes to make up the difference
+        byte[] b = new byte[defaultRWBufferSize];
+        while (raf.length() < length) {
+          raf.seek(raf.length());
+          int len = (int) Math.min(b.length, length - raf.length());
+          raf.write(b, 0, len);
+        }
+      }
     }
     raf.seek(length - 1);
     buffer = null;


### PR DESCRIPTION
This should fix https://github.com/openmicroscopy/bioformats/pull/3189#issuecomment-410805187, which was reproducible on necromancer using both east and develop (independent of openmicroscopy/bioformats#3189 itself).

Debugging showed that conversion consistently stopped when the file length was ```356495873```, then a call to write 65536 bytes (one tile) triggered a call to ```NIOFileHandle.setLength(356561409)``` which resulted in a file of length ```356515840```.  Since the file was only partially extended, the subsequent buffer re-positioning failed.  Adding a check to ```setLength``` in ```NIOFileHandle``` so that ```raf.write(...)``` is called if ```raf.setLength(...)``` doesn't result in the expected length seems to work.

As far as I can tell, this is specific to writing on a network file system (or at least, writing under ```/ome/```).  I can reproduce the problem without this PR on necromancer when writing under ```/ome/team/mlinkert/```, but not when writing under ```/homes/mlinkert/```.  This is consistent with my not being able to reproduce the problem on local machines and @pwalczysko's successful local ```bfconvert``` tests.  I'm still not really sure exactly why ```RandomAccessFile.setLength(...)``` sometimes quietly doesn't do what it's told, but this is at least a place to start.  