### PR TITLE
DataTools: fix subtle bug in scientific notation parsing

### DIFF
--- a/src/main/java/loci/common/DataTools.java
+++ b/src/main/java/loci/common/DataTools.java
@@ -657,7 +657,10 @@ public final class DataTools {
   public static Float parseFloat(String value) {
     if (value == null) return null;
     try {
-      return nf.get().parse(value.replaceAll(",", ".")).floatValue();
+      // upper-case before parsing to ensure that scientific notation
+      // is handled correctly
+      String toParse = value.replaceAll(",", ".").toUpperCase();
+      return nf.get().parse(toParse).floatValue();
     } catch (ParseException e) {
       LOGGER.debug("Could not parse float value", e);
     }
@@ -673,7 +676,10 @@ public final class DataTools {
   public static Double parseDouble(String value) {
     if (value == null) return null;
     try {
-      return nf.get().parse(value.replaceAll(",", ".")).doubleValue();
+      // upper-case before parsing to ensure that scientific notation
+      // is handled correctly
+      String toParse = value.replaceAll(",", ".").toUpperCase();
+      return nf.get().parse(toParse).doubleValue();
     } catch (ParseException e) {
       LOGGER.debug("Could not parse double value", e);
     }
@@ -694,6 +700,9 @@ public final class DataTools {
     char separator = new DecimalFormatSymbols().getDecimalSeparator();
     char usedSeparator = separator == '.' ? ',' : '.';
     value = value.replace(usedSeparator, separator);
+    // upper-case before parsing to ensure that scientific notation
+    // is handled correctly
+    value = value.toUpperCase();
     try {
       Double.parseDouble(value);
     }

--- a/src/test/java/loci/common/utests/DataToolsTest.java
+++ b/src/test/java/loci/common/utests/DataToolsTest.java
@@ -228,6 +228,8 @@ public class DataToolsTest {
     assertEquals(DataTools.parseDouble("0.1"), 0.1d);
     assertEquals(DataTools.parseDouble("0,1"), 0.1d);
     assertEquals(DataTools.parseDouble("not a number"), null);
+    assertEquals(DataTools.parseDouble("2.5E-005"), 0.000025);
+    assertEquals(DataTools.parseDouble("1.5e-005"), 0.000015);
   }
   
   @Test(threadPoolSize = 10, invocationCount = 1000)


### PR DESCRIPTION
Noticed while looking at https://trello.com/c/Fig1abYV/239-lif-parsedouble-exception

0a0b380 adds cases for testing how ```parseDouble(String)``` handles scientific notation.  Without 0467a8a, the first case will pass but the second will fail.  If ```e``` is used as the exponent separator instead of ```E```, then the exponent will be ignored.

0467a8a fixes the test by upper-casing input strings to ```parseDouble(String)```, ```parseFloat(String)```, and ```sanitizeDouble(String)```.

I don't how much impact this will have on data tests, but it's possible that some physical sizes and/or plane positions will change.  If failures are introduced, happy to have this excluded after one test run to reduce noise until a configuration PR can be opened.