### PR TITLE
Deprecate CaseInsensitiveLocation

### DIFF
--- a/src/main/java/loci/common/CaseInsensitiveLocation.java
+++ b/src/main/java/loci/common/CaseInsensitiveLocation.java
@@ -39,7 +39,9 @@ import java.util.HashSet;
 
 /**
  * Case insensitive variant of Location.
+ * @deprecated use {@link Location} instead
  */
+@Deprecated
 public class CaseInsensitiveLocation extends Location {
 
   // Fields


### PR DESCRIPTION
See https://github.com/openmicroscopy/bioformats/pull/3217 and https://trello.com/c/gJ2nQw9v/29-zeiss-tiff-distributed-failures.

With that PR, ```CaseInsensitiveLocation``` is no longer used in Bio-Formats.  The thread safety issues noted on the Trello card suggest that using ```CaseInsensitiveLocation``` at all is not recommended.

To test, verify that no other OME code makes use of ```CaseInsensitiveLocation```.  All builds should continue to pass.