### PR TITLE
NIOFileHandle: don't read from the file to fill a trash buffer

### DIFF
--- a/src/main/java/loci/common/NIOFileHandle.java
+++ b/src/main/java/loci/common/NIOFileHandle.java
@@ -502,10 +502,12 @@ public class NIOFileHandle extends AbstractNIOHandle {
   /* @see IRandomAccess.write(ByteBuffer, int, int) */
   @Override
   public void write(ByteBuffer buf, int off, int len) throws IOException {
-    writeSetup(len);
+    // Don't bother with writeSetup() because we're just throwing the buffer away again.
+    // Also, the channel.write() will handle resizing the file as needed.
     buf.limit(off + len);
     buf.position(off);
     position += channel.write(buf, position);
+    raf.seek(position);
     buffer = null;
   }
 


### PR DESCRIPTION
The writeSetup method in NIOFileHandle ensures that the buffer used for speeding up reads is aligned sanely with any write that we're going to do, so that we can also use it as a write-through cache.  In the process, it may resize the buffer and read into it from the file on disk.  However, the write method taking a ByteBuffer immediately throws away that read buffer, so resizing it and filling it is simply a waste of time.

This work was motivated by the desire to speed up image format conversions for image files in excess of 50GB. In conjunction with additional changes in bioformats and ome-codecs, I have achieved a geometric to linear time asymptotic improvement, plus another ~30% speed improvement of just the linear time cost. The patch for ome-codecs has already been submitted, and the patches for bioformats will be forthcoming in the next few days.