### PR TITLE
Location Parent NPE

### DIFF
--- a/src/main/java/loci/common/Location.java
+++ b/src/main/java/loci/common/Location.java
@@ -870,7 +870,9 @@ public class Location {
    * @see java.io.File#getParentFile()
    */
   public Location getParentFile() {
-    return new Location(getParent());
+    String parent = this.getParent();
+    if (parent == null) return null;
+    return new Location(parent);
   }
 
   /**

--- a/src/main/java/loci/common/Location.java
+++ b/src/main/java/loci/common/Location.java
@@ -57,7 +57,7 @@ import com.google.common.collect.MapMaker;
 
 /**
  * Pseudo-extension of {@link java.io.File} that supports reading over HTTP
- * (among  other things).
+ * (among other things).
  * It is strongly recommended to use this instead of java.io.File.
  */
 public class Location {

--- a/src/main/java/loci/common/Location.java
+++ b/src/main/java/loci/common/Location.java
@@ -876,8 +876,8 @@ public class Location {
    * If the name sequence is empty then the pathname does not name a parent
    * directory.
    *
-   * @return the Location representing {@link #getParent()}
-   *
+   * @return The abstract pathname of the parent directory named by this
+   * abstract pathname, or null if this pathname does not name a parent
    * @see java.io.File#getParentFile()
    */
   public Location getParentFile() {

--- a/src/main/java/loci/common/Location.java
+++ b/src/main/java/loci/common/Location.java
@@ -246,7 +246,7 @@ public class Location {
    * @see #Location(String, String)
    */
   public Location(Location parent, String child) {
-    this(parent.getAbsolutePath(), child);
+    this(parent == null ? (String) null : parent.getAbsolutePath(), child);
   }
 
   // -- Location API methods --

--- a/src/main/java/loci/common/Location.java
+++ b/src/main/java/loci/common/Location.java
@@ -56,8 +56,8 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.MapMaker;
 
 /**
- * Pseudo-extension of java.io.File that supports reading over HTTP (among
- * other things).
+ * Pseudo-extension of {@link java.io.File} that supports reading over HTTP
+ * (among  other things).
  * It is strongly recommended to use this instead of java.io.File.
  */
 public class Location {
@@ -842,9 +842,13 @@ public class Location {
   }
 
   /**
-   * Returns the name of this file's parent directory, i.e. the path name prefix
-   * and every name in the path name sequence except for the last.
-   * If this file does not have a parent directory, then null is returned.
+   * Returns the pathname string of this abstract pathname's parent, or null if
+   * this pathname does not have a parent directory.
+   *
+   * The parent of an abstract pathname consists of the pathname's prefix, if
+   * any, and each name in the pathname's name sequence except for the last.
+   * If the name sequence is empty then the pathname does not name a parent
+   * directory.
    *
    * @return see above
    * @see java.io.File#getParent()
@@ -864,9 +868,16 @@ public class Location {
   }
 
   /**
-   * Returns this file's parent directory.
+   * Returns the abstract pathname of this abstract pathname's parent, or null
+   * if this pathname does not name a parent directory.
+   *
+   * The parent of an abstract pathname consists of the pathname's prefix, if
+   * any, and each name in the pathname's name sequence except for the last.
+   * If the name sequence is empty then the pathname does not name a parent
+   * directory.
    *
    * @return the Location representing {@link #getParent()}
+   *
    * @see java.io.File#getParentFile()
    */
   public Location getParentFile() {

--- a/src/test/java/loci/common/utests/LocationTest.java
+++ b/src/test/java/loci/common/utests/LocationTest.java
@@ -272,7 +272,7 @@ public class LocationTest {
       assertEquals(file.getName(), null, file.getParent());
     }
   }
-  
+
   @Test
   public void testParentNull() {
     Location nullParent = new Location((String) null, "nullParentFile");

--- a/src/test/java/loci/common/utests/LocationTest.java
+++ b/src/test/java/loci/common/utests/LocationTest.java
@@ -274,7 +274,7 @@ public class LocationTest {
   
   @Test
   public void testParentNull() {
-    Location nullParent = new Location("nullParentFile", null);
+    Location nullParent = new Location(null, "nullParentFile");
     assertEquals(nullParent.getName(), null, nullParent.getParentFile());
   }
 

--- a/src/test/java/loci/common/utests/LocationTest.java
+++ b/src/test/java/loci/common/utests/LocationTest.java
@@ -275,9 +275,9 @@ public class LocationTest {
   @Test
   public void testParentNull() {
     Location nullParent = new Location((String) null, "nullParentFile");
-    assertEquals(nullParent.getName(), null, nullParent.getParentFile());
+    assertEquals(nullParent.getName(), String.valueOf("null"), nullParent.getParentFile());
     nullParent = new Location((Location) null, "nullParentFile");
-    assertEquals(nullParent.getName(), null, nullParent.getParentFile());
+    assertEquals(nullParent.getName(), String.valueOf("null"), nullParent.getParentFile());
   }
 
   @Test

--- a/src/test/java/loci/common/utests/LocationTest.java
+++ b/src/test/java/loci/common/utests/LocationTest.java
@@ -33,6 +33,7 @@
 package loci.common.utests;
 
 import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
 
 import java.io.File;
 import java.io.IOException;
@@ -275,9 +276,9 @@ public class LocationTest {
   @Test
   public void testParentNull() {
     Location nullParent = new Location((String) null, "nullParentFile");
-    assertEquals(nullParent.getName(), String.valueOf("null"), nullParent.getParentFile());
+    assertNull(nullParent.getParentFile());
     nullParent = new Location((Location) null, "nullParentFile");
-    assertEquals(nullParent.getName(), String.valueOf("null"), nullParent.getParentFile());
+    assertNull(nullParent.getParentFile());
   }
 
   @Test

--- a/src/test/java/loci/common/utests/LocationTest.java
+++ b/src/test/java/loci/common/utests/LocationTest.java
@@ -274,7 +274,9 @@ public class LocationTest {
   
   @Test
   public void testParentNull() {
-    Location nullParent = new Location(null, "nullParentFile");
+    Location nullParent = new Location((String) null, "nullParentFile");
+    assertEquals(nullParent.getName(), null, nullParent.getParentFile());
+    nullParent = new Location((Location) null, "nullParentFile");
     assertEquals(nullParent.getName(), null, nullParent.getParentFile());
   }
 

--- a/src/test/java/loci/common/utests/LocationTest.java
+++ b/src/test/java/loci/common/utests/LocationTest.java
@@ -271,6 +271,12 @@ public class LocationTest {
       assertEquals(file.getName(), null, file.getParent());
     }
   }
+  
+  @Test
+  public void testParentNull() {
+    Location nullParent = new Location("nullParentFile", null);
+    assertEquals(nullParent.getName(), null, nullParent.getParentFile());
+  }
 
   @Test
   public void testIsDirectory() {


### PR DESCRIPTION
See #12, #14 and https://trello.com/c/Ym1HWlQG/73-ome-common-location-exception

This PR resurrect the `Location.getParentFile()` NPE fix proposed in #12 but pushed away as potentially breaking now we are converging towards 6.0.0.

- reintroduces the unit tests from #12 showing the new expected behavior
- updates the Javadoc to reuse `java.io.File` as `Location` is a direct extension/replacement of this class
- re-introduces the fix for the new behavior (`getParentFile()` return `null` if `getParent` is `null` rather than throwing a NPE). Incidentally, #33 fixed one of the 2 constructors and c4e54a0  fixes the second one.

