### PR TITLE
Exclude some minio transitive dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,20 @@
      <groupId>io.minio</groupId>
      <artifactId>minio</artifactId>
      <version>5.0.2</version>
+     <exclusions>
+       <exclusion>
+	 <groupId>commons-codec</groupId>
+	 <artifactId>commons-codec</artifactId>
+       </exclusion>
+       <exclusion>
+	 <groupId>commons-logging</groupId>
+	 <artifactId>commons-logging</artifactId>
+       </exclusion>
+       <exclusion>
+	 <groupId>com.google.code.findbugs</groupId>
+	 <artifactId>annotations</artifactId>
+       </exclusion>
+     </exclusions>
     </dependency>
     <dependency>
      <groupId>com.esotericsoftware.kryo</groupId>


### PR DESCRIPTION
Excludes some possibly troublesome transitive dependencies introduced by the S3 work.

- commons-codec:commons-codec
- commons-logging:commons-logging
- com.google.code.findbugs:annotations

See https://trello.com/c/5l4Vrbcd/117-review-common-codecs-dependency and https://sourceforge.net/p/findbugs/bugs/1341/.