### PR TITLE
Bump Guava dependency up to version 27.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>17.0</version>
+      <version>27.1-jre</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
27.1 is the current release.

Also exceeds what OMERO's MinIO requires so then we don't need two.