### PR TITLE
Also exclude jsr305 dependency from minio

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,16 +107,20 @@
      <version>5.0.2</version>
      <exclusions>
        <exclusion>
-	 <groupId>commons-codec</groupId>
-	 <artifactId>commons-codec</artifactId>
+         <groupId>commons-codec</groupId>
+         <artifactId>commons-codec</artifactId>
        </exclusion>
        <exclusion>
-	 <groupId>commons-logging</groupId>
-	 <artifactId>commons-logging</artifactId>
+         <groupId>commons-logging</groupId>
+         <artifactId>commons-logging</artifactId>
        </exclusion>
        <exclusion>
-	 <groupId>com.google.code.findbugs</groupId>
-	 <artifactId>annotations</artifactId>
+         <groupId>com.google.code.findbugs</groupId>
+         <artifactId>annotations</artifactId>
+       </exclusion>
+       <exclusion>
+         <groupId>com.google.code.findbugs</groupId>
+         <artifactId>jsr305</artifactId>
        </exclusion>
      </exclusions>
     </dependency>


### PR DESCRIPTION
The version 3.0.2 of this dependency is pulled as a transitive dependency from Guava. In addition to being more up-to-date, pulling this version should work better with the full stack integration

/cc @joshmoore  