### PR TITLE
Fix the mc policy command following the 2019-07 release

### DIFF
--- a/location-server/start-location.sh
+++ b/location-server/start-location.sh
@@ -31,4 +31,4 @@ for SUFFIX in public private; do
         ./mc pipe ome-common-java-minio-test/bioformats.test.$SUFFIX/2MBfile.txt
 done
 
-./mc policy public ome-common-java-minio-test/bioformats.test.public
+./mc policy set public ome-common-java-minio-test/bioformats.test.public


### PR DESCRIPTION
Travis has been failing since the breaking release of the `mc` utility (see https://travis-ci.org/ome/ome-common-java/jobs/565903545) -see https://github.com/minio/mc/releases/tag/RELEASE.2019-08-07T23-14-43Z and especially the breaking changes for the mc policy setting functionality

This change should update the `start-location.sh` code to use the newest `mc policy set` semantics and restore the build.