### PR TITLE
Update to the newest stable release of kryo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,9 +121,9 @@
      </exclusions>
     </dependency>
     <dependency>
-     <groupId>com.esotericsoftware.kryo</groupId>
+     <groupId>com.esotericsoftware</groupId>
      <artifactId>kryo</artifactId>
-     <version>2.24.0</version>
+     <version>4.0.2</version>
     </dependency>
     <dependency>
       <groupId>joda-time</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -71,10 +71,6 @@
     </mailingList>
   </mailingLists>
 
-  <prerequisites>
-    <maven>3.0.5</maven>
-  </prerequisites>
-
   <scm>
     <connection>scm:git:https://github.com/ome/ome-common-java</connection>
     <developerConnection>scm:git:git@github.com:ome/ome-common-java</developerConnection>


### PR DESCRIPTION
From 2.24.0 to 3.0.0, the kryo project changed its groupId from `com.esotericsoftware.kryo` to `com.esotericsoftware`. Therefore, from Maven's perspective, both of these artifacts can be present on the classpath at the same time, creating duplicate class conflicts. Unfortunately, this scenario is happening when attempting to combine `org.openmicroscopy:ome-common:6.0.4` (which wants kryo 2.24.0) with `graphics.scenery:scenery:0.7.0-beta-7` (which wants kryo 4.0.2).

One solution to this dilemma is to update the version of kryo here to 4.0.2, which is what this PR does. The code still compiles, and tests pass, although I am not certain how thorough (if at all) the kryo-related functionality is exercised.

What do you think? Is this a good way forward?