### PR TITLE
Fix minio version command

### DIFF
--- a/location-server/start-location.sh
+++ b/location-server/start-location.sh
@@ -9,7 +9,7 @@ PLATFORM=`uname | tr '[:upper:]' '[:lower:]'`
 [ -f mc ] || \
     curl -sfSo mc "https://dl.minio.io/client/mc/release/$PLATFORM-amd64/mc"
 chmod +x minio mc
-./minio version
+./minio --version
 ./mc version
 
 export MINIO_ACCESS_KEY=accesskey MINIO_SECRET_KEY=secretkey


### PR DESCRIPTION
The `version` subcommand seems to have been removed in recent versions of the `minio` server causing Travis to fail on #49 and #50.