### PR TITLE
Bump logback-classic and logback-core to 1.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,13 +146,13 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
-      <version>1.1.1</version>
+      <version>1.2.0</version>
     </dependency>
     <dependency>
       <!-- NB: We want this, despite warning from dependency:analyze. -->
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.1.1</version>
+      <version>1.2.0</version>
     </dependency>
     <dependency>
       <!-- NB: We want this, despite warning from dependency:analyze. -->


### PR DESCRIPTION
Supersedes #56 and #57

It looks like both dependencies need to be bumped at the same time to pass the Maven tests