### PR TITLE
Add JDK 17 to the testing matrix

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [1.8, 11]
+        java: [1.8, 11, 17]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
See https://github.com/ome/bio-formats-build/pull/274#issuecomment-1121286378

This starts the process of adding OpenJDK 17 to the list of Java environments against which each push/pull event should be tested