### PR TITLE
Bump jackson dependencies to 2.9.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
 
     <plugins>
       <plugin>
-  <groupId>org.apache.maven.plugins</groupId>
+       <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.7.0</version>
         <!-- Require the Java 8 platform. -->

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,29 @@
          <groupId>com.google.code.findbugs</groupId>
          <artifactId>jsr305</artifactId>
        </exclusion>
+       <exclusion>
+         <groupId>com.fasterxml.jackson.core</groupId>
+         <artifactId>jackson-databind</artifactId>
+       </exclusion>
+       <exclusion>
+         <groupId>com.fasterxml.jackson.core</groupId>
+         <artifactId>jackson-core</artifactId>
+       </exclusion>
+       <exclusion>
+         <groupId>com.fasterxml.jackson.core</groupId>
+         <artifactId>jackson-annotations</artifactId>
+       </exclusion>
      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.9.8</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>2.9.8</version>
     </dependency>
     <dependency>
      <groupId>com.esotericsoftware</groupId>
@@ -204,7 +226,7 @@
 
     <plugins>
       <plugin>
-	<groupId>org.apache.maven.plugins</groupId>
+  <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.7.0</version>
         <!-- Require the Java 8 platform. -->

--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
 
     <plugins>
       <plugin>
-       <groupId>org.apache.maven.plugins</groupId>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.7.0</version>
         <!-- Require the Java 8 platform. -->


### PR DESCRIPTION
A follow on from the ongoing dependency alignment discussions in https://github.com/ome/openmicroscopy/pull/6328
This will bump the 3 jackson dependencies from 2.9.6 to 2.9.8 by excluding them from minio and adding direct depdencies to common-java. Note annotations needed to be added in addition to databind as databind uses annotations 2.9.0 as dependency.
```
com.fasterxml.jackson.core:jackson-annotations:jar
com.fasterxml.jackson.core:jackson-core:jar
com.fasterxml.jackson.core:jackson-databind:jar
```