### PR TITLE
Unify jackson-databind and jackson-annotations versions to 2.12.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,12 +135,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.6.1</version>
+      <version>2.12.7</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.9.8</version>
+      <version>2.12.7</version>
     </dependency>
     <dependency>
      <groupId>com.esotericsoftware</groupId>


### PR DESCRIPTION
Motivated by the import issues raised in https://github.com/ome/ZarrReader/issues/39 /cc @pwalczysko 

As per the recommendations, this commit bump the jackson-* components to use the same minor versions and prevent incompatibility issues.

