### PR TITLE
Make logback dependencies optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,12 +169,14 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
       <version>1.2.9</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <!-- NB: We want this, despite warning from dependency:analyze. -->
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>1.2.9</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <!-- NB: We want this, despite warning from dependency:analyze. -->


### PR DESCRIPTION
The `ch.qos.logback` classes are used only in `loci.common.LogbackTools`, which is accessed solely via reflection from `loci.common.DebugTools`.

It is best practice for libraries not to impose any specific SLF4J binding on downstream consumers.

> Embedded components such as libraries or frameworks should not declare a dependency on any SLF4J binding but only depend on slf4j-api.

[Source](https://www.slf4j.org/manual.html#libraries)
