### PR TITLE
Bump jackson-databind and jackson-annotations to 2.14.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,12 +135,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.7</version>
+      <version>2.14.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.12.7</version>
+      <version>2.14.1</version>
     </dependency>
     <dependency>
      <groupId>com.esotericsoftware</groupId>


### PR DESCRIPTION
Following on from https://github.com/ome/ome-common-java/pull/69 and https://github.com/ome/ome-common-java/pull/70. Bumping both of the components to the latest available minor release 2.14.1

See https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.14 for the changes