### PR TITLE
Bump sl4j-api to 2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>2.0.4</version>
+      <version>2.0.9</version>
     </dependency>
 
     <!-- NB: dependency:analyze has false warning about xml-apis:xml-apis. -->
@@ -168,14 +168,14 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
-      <version>1.3.5</version>
+      <version>1.3.11</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <!-- NB: We want this, despite warning from dependency:analyze. -->
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.3.5</version>
+      <version>1.3.11</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>2.0.6</version>
+      <version>2.0.4</version>
     </dependency>
 
     <!-- NB: dependency:analyze has false warning about xml-apis:xml-apis. -->

--- a/pom.xml
+++ b/pom.xml
@@ -168,14 +168,14 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
-      <version>1.3.11</version>
+      <version>1.3.13</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <!-- NB: We want this, despite warning from dependency:analyze. -->
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.3.11</version>
+      <version>1.3.13</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.6</version>
+      <version>2.0.6</version>
     </dependency>
 
     <!-- NB: dependency:analyze has false warning about xml-apis:xml-apis. -->
@@ -168,14 +168,14 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
-      <version>1.2.9</version>
+      <version>1.3.5</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <!-- NB: We want this, despite warning from dependency:analyze. -->
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.9</version>
+      <version>1.3.5</version>
       <optional>true</optional>
     </dependency>
     <dependency>


### PR DESCRIPTION
See https://github.com/ome/bioformats/pull/3956

This commit explores upgrading the slf4-api version to 2.x. For concrete implementations, this means logback should be upgraded either to 1.3.x (Java 8+) or 1.4.x (Java 11+)