### PR TITLE
Bump guava version to 31.1-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>29.0-jre</version>
+      <version>31.1-jre</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Bumping the guava dependency to match the updated FIJI version  as in https://github.com/ome/bioformats/issues/3970

The impact here is not so much on the Bio-Formats stack but on downstream components such as OMERO.

Also included in the FIJI version bumps are some components downstream of guava:

- checker-qual  is now 3.32.0
- j2objc-annotations  is now 2.8
- error_prone_annotations  is now 2.18.0

These versions differ from those included with this guava bump to 31.1:

```
+- com.google.guava:guava:jar:31.1-jre:compile
|  +- org.checkerframework:checker-qual:jar:3.12.0:compile
|  +- com.google.errorprone:error_prone_annotations:jar:2.11.0:compile
|  \- com.google.j2objc:j2objc-annotations:jar:1.3:compile
```

Realistically though these dependencies will not be used by the Bio-Formats plugin in the FIJI environment so the impact of the new FIJI versions is likely to be low in this case. 