### PR TITLE
Bump jackson dependencies to 2.14.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,12 +135,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.14.1</version>
+      <version>2.14.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.14.1</version>
+      <version>2.14.2</version>
     </dependency>
     <dependency>
      <groupId>com.esotericsoftware</groupId>


### PR DESCRIPTION
Bumping the jackson dependencies to match the updated FIJI version as in https://github.com/ome/bioformats/issues/3970