### PR TITLE
Bump joda-time to 2.12.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-      <version>2.2</version>
+      <version>2.12.2</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Bumping the joda-time dependency to 2.12.2 in order to align with the latest FIJI versions.
See https://github.com/ome/bioformats/issues/3970