### PR TITLE
Remove reference to WlzService

### DIFF
--- a/src/main/java/loci/common/services/services.properties
+++ b/src/main/java/loci/common/services/services.properties
@@ -54,8 +54,6 @@ loci.formats.services.LuraWaveService=loci.formats.services.LuraWaveServiceImpl
 loci.formats.services.MetakitService=loci.formats.services.MetakitServiceImpl
 # libjpeg-turbo service
 loci.formats.services.JPEGTurboService=loci.formats.services.JPEGTurboServiceImpl
-# Woolz service (interface and implementation in bio-formats)
-loci.formats.services.WlzService=loci.formats.services.WlzServiceImpl
 loci.formats.services.EXIFService=loci.formats.services.EXIFServiceImpl
 loci.formats.services.JPEGXRService=loci.formats.services.JPEGXRServiceImpl
 # Minio S3 client service


### PR DESCRIPTION
See https://github.com/ome/bioformats/pull/4014

I expect we'll want this for Bio-Formats 7.0.0, but not for 6.14.0 (hence exclude label).