### PR TITLE
URLHandle: fall back to resetting stream if resetting to a mark fails

### DIFF
--- a/src/main/java/loci/common/URLHandle.java
+++ b/src/main/java/loci/common/URLHandle.java
@@ -80,9 +80,19 @@ public class URLHandle extends StreamHandle {
   @Override
   public void seek(long pos) throws IOException {
     if (pos < fp && pos >= mark) {
-      stream.reset();
-      fp = mark;
-      skip(pos - fp);
+      try {
+        // try to reset to the marked position first
+        // if it works, this is faster
+        stream.reset();
+        fp = mark;
+        skip(pos - fp);
+      }
+      catch (IOException e) {
+        // if resetting to the mark fails for whatever reason,
+        // just reset the whole stream and seek from the beginning
+        // this is slower but more likely to work
+        super.seek(pos);
+      }
     }
     else super.seek(pos);
   }


### PR DESCRIPTION
See https://github.com/ome/bioformats/issues/3918

I believe this will help with the first problem in that issue:

```
Caused by: java.io.IOException: Resetting to invalid mark
	at java.io.BufferedInputStream.reset(BufferedInputStream.java:448)
	at java.io.FilterInputStream.reset(FilterInputStream.java:226)
	at loci.common.URLHandle.seek(URLHandle.java:83)
	at loci.common.RandomAccessInputStream.seek(RandomAccessInputStream.java:203)
```

as this will force the whole stream to be reinitialized if resetting to the marked position fails when seeking backwards. I don't have a good way to test this though, as I wasn't actually able to reproduce the original exception.