### PR TITLE
Use Maven profiles to handle different versions of TestNG

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,13 @@
       <version>2.7.3</version>
       <scope>runtime</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <version>${testng.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <properties>
@@ -470,28 +477,18 @@
       <activation>
         <jdk>(,11)</jdk>
       </activation>
-      <dependencies>
-        <dependency>
-          <groupId>org.testng</groupId>
-          <artifactId>testng</artifactId>
-          <version>7.5</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
+      <properties>
+        <testng.version>7.5</testng.version>
+      </properties>
     </profile>
     <profile>
       <id>jdk11+</id>
       <activation>
         <jdk>[11,)</jdk>
       </activation>
-      <dependencies>
-        <dependency>
-          <groupId>org.testng</groupId>
-          <artifactId>testng</artifactId>
-          <version>7.9.0</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
+      <properties>
+        <testng.version>7.9.0</testng.version>
+      </properties>
     </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -192,13 +192,6 @@
       <version>2.7.3</version>
       <scope>runtime</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.testng</groupId>
-      <artifactId>testng</artifactId>
-      <version>6.8</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <properties>
@@ -471,6 +464,34 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>jdk8-only</id>
+      <activation>
+        <jdk>(,11)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.testng</groupId>
+          <artifactId>testng</artifactId>
+          <version>7.5</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>jdk11+</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.testng</groupId>
+          <artifactId>testng</artifactId>
+          <version>7.9.0</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Replaces #72 using the strategy discussed in https://github.com/ome/bioformats/pull/4159#issuecomment-1977740538

- For JDK8, bump org.testng:testng to the last supported release for this version i.e. 7.5
- For JDK11+, bump org.testng:testng to the latest release 7.9.0