### PR TITLE
Fix string comparison

### DIFF
--- a/src/main/java/loci/common/LogbackTools.java
+++ b/src/main/java/loci/common/LogbackTools.java
@@ -69,7 +69,7 @@ public final class LogbackTools {
     Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
     LoggerContext loggerContext = root.getLoggerContext();
     return (ConfigurationWatchListUtil.getMainWatchURL(loggerContext) != null
-            || (loggerContext.getProperty("caller") == CALLER));
+            || (loggerContext.getProperty("caller").equals(CALLER)));
   }
 
   /**


### PR DESCRIPTION
Fixes #89.

I'm not sure this will actually affect behavior in practice, given that the `caller` property is only set to the `CALLER` variable in this class, but the string equality check should now be technically correct.