### PR TITLE
Activate Javadoc in CI builds

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,7 +17,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     env:
-      maven_commands: test # default is install
+      maven_commands: test javadoc:javadoc # default is install
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}

--- a/pom.xml
+++ b/pom.xml
@@ -341,9 +341,9 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <!-- NB: The same version declaration and configuration block also
              appears in the <reporting> section, and must be kept in sync. -->
-        <version>3.0.1</version>
+        <version>3.10.0</version>
         <configuration>
-          <failOnError>false</failOnError>
+          <failOnError>true</failOnError>
           <links>
             <link>http://docs.oracle.com/javase/8/docs/api/</link>
           </links>


### PR DESCRIPTION
Fixes #2 

Errors have already been fixed, this is primarily activating the Javadoc target in the CI builds.