### PR TITLE
Only declare logback-classic as a runtime dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,13 +167,6 @@
 
     <dependency>
       <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
-      <version>1.3.14</version>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <!-- NB: We want this, despite warning from dependency:analyze. -->
-      <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>1.3.14</version>
       <optional>true</optional>


### PR DESCRIPTION
In the current POM, logback-core and logback-classic and declared separately and bumped individually by the dependabot agent. This can be an issue for logback releases including backwards-incompatible API changes. This was the case in https://github.com/ome/ome-common-java/pull/93 and more recently in https://github.com/ome/ome-common-java/pull/94 where the GitHub Actions tests failed due to the backported removal of `JaninoEventEvaluator` in [1.3.15](https://logback.qos.ch/news.html#1.3.15).

Given the strong coupling of `logback-core` and `logback-classic`, 0a4140f237a86ec1801233ef355e694dcd5fb0e4 removes the declaration of `logback-core` from `pom.xml`. The version should now be resolved as a transitive dependency of `logback-classic`.