### PR TITLE
Bump logback-classic to 1.3.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.3.14</version>
+      <version>1.3.15</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/src/test/java/loci/common/utests/testng-template.xml
+++ b/src/test/java/loci/common/utests/testng-template.xml
@@ -30,6 +30,7 @@
   #L%
   -->
 
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 <suite name="IO_Tests">
     <test name="ByteArrayHandle">
         <parameter name="provider" value="ByteArrayHandle"/>


### PR DESCRIPTION
See https://logback.qos.ch/news.html#1.3.15

Also add the TestNG DTD to the top of the XML file to silence warnings