### PR TITLE
Fix type of skipped bytes counter

### DIFF
--- a/src/main/java/loci/common/BZip2Handle.java
+++ b/src/main/java/loci/common/BZip2Handle.java
@@ -105,7 +105,7 @@ public class BZip2Handle extends StreamHandle {
   protected void resetStream() throws IOException {
     BufferedInputStream bis = new BufferedInputStream(
       new FileInputStream(file), RandomAccessInputStream.MAX_OVERHEAD);
-    int skipped = 0;
+    long skipped = 0;
     while (skipped < 2) {
       skipped += bis.skip(2 - skipped);
     }


### PR DESCRIPTION
`BufferedInputStream.skip` both accepts and returns a `long`, so using a `long` counter should be safer.