### PR TITLE
Remove jackson dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,16 +123,6 @@
      </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.14.2</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-      <version>2.14.2</version>
-    </dependency>
-    <dependency>
      <groupId>com.esotericsoftware</groupId>
      <artifactId>kryo</artifactId>
      <version>5.4.0</version>


### PR DESCRIPTION
Partially replaces  #108 (in order to handle that separetely from the s3 case).

Projects using jackson libs:
https://github.com/search?q=org%3Aome+%22import+com.fasterxml.jackson%22&type=code

- ome/omero-insight: Opened PR: https://github.com/ome/omero-insight/pull/477 
- ome/jzarr: Can be ignored?
- ome/omero-ms-image-region: Used in integration tests. Opened PR: https://github.com/ome/omero-ms-image-region/pull/8
- ome/raw2ometiff: Used in integration tests.
- ome/bioformats2raw: Used in integration tests.
- ome/omero-zarr-pixel-buffer: Used in integration tests.

I really don't understand how this dependency trickles down to all these projects. Do we need PRs for all of them to declare the dependency explictely after it has been removed from ome-common-java?

Specifically how it trickles down to the server installation, because there's the problem when you want to use omero-zarr-pixelbuffer with latest zarr-java (which is my fault bumping the version there https://github.com/zarr-developers/zarr-java/pull/26 ; I did not expect what a can of worms that opened...)

