### PR TITLE
Make sure length() returns the correct value when Location represents a mapped file

### DIFF
--- a/src/main/java/loci/common/Location.java
+++ b/src/main/java/loci/common/Location.java
@@ -234,8 +234,9 @@ public class Location {
       mapped = getMappedId(pathname);
     }
 
-    if (!isURL) file = new File(mapped);
-
+    if (!isURL) {
+      file = new File(mapped);
+    }
   }
 
   /**
@@ -1016,6 +1017,15 @@ public class Location {
       // Ensure cachedProperties is populated
       exists();
       return cachedProperties.length;
+    }
+    IRandomAccess handle = getMappedFile(file.getName());
+    if (handle != null && !file.exists()) {
+      try {
+        return handle.length();
+      }
+      catch (IOException e) {
+        LOGGER.warn("Could not get length", e);
+      }
     }
     LOGGER.trace("length(file)");
     return file.length();


### PR DESCRIPTION
Also adds relevant unit tests. This is another (possibly complementary) approach to https://github.com/ome/bioformats/pull/4414. 

Another option would be to reject this change, but document that constructing a `Location` that represents a mapped `IRandomAccess` doesn't necessarily work as expected, and replace any known instances of that pattern with `Location.getHandle(mappedName).length()` or similar.