### PR TITLE
Require Java 11 at runtime, build on Java 21/25

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,15 +34,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        java: [21, 25]
+        java: [11, 17, 21, 25]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,15 +15,15 @@ jobs:
       contents: read
     strategy:
       matrix:
-        java: [8, 11, 17, 21]
+        java: [21, 25]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     env:
       maven_commands: test javadoc:javadoc # default is install
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
@@ -37,7 +37,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Create a GitHub release
         run: gh release create --generate-notes "${GITHUB_REF#refs/tags/}"
         env:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ following before submitting a pull request:
 
  * verify that the branch merges cleanly into ```master```
  * verify that the branch builds using Maven
- * verify that the branch does not use syntax or API specific to Java 1.9+
+ * verify that the branch does not use syntax or API specific to Java > 11
  * run the unit tests (```mvn test```) and correct any failures
  * make sure that your commits contain the correct authorship information
  * make sure that the commit messages or pull request comment contains

--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,8 @@
   </dependencies>
 
   <properties>
+    <testng.version>7.9.0</testng.version>
+
     <!-- NB: Avoid platform encoding warning when copying resources. -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -214,11 +216,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.14.0</version>
-        <!-- Require the Java 8 platform. -->
+        <!-- Require the Java 11 platform. -->
         <configuration>
-          <release>8</release>
-          <source>8</source>
-          <target>8</target>
+          <release>11</release>
         </configuration>
       </plugin>
 
@@ -329,7 +329,7 @@
         <configuration>
           <failOnError>true</failOnError>
           <links>
-            <link>http://docs.oracle.com/javase/8/docs/api/</link>
+            <link>http://docs.oracle.com/javase/11/docs/api/</link>
           </links>
         </configuration>
         <executions>
@@ -454,24 +454,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-    <profile>
-      <id>jdk8-only</id>
-      <activation>
-        <jdk>(,11)</jdk>
-      </activation>
-      <properties>
-        <testng.version>7.5</testng.version>
-      </properties>
-    </profile>
-    <profile>
-      <id>jdk11+</id>
-      <activation>
-        <jdk>[11,)</jdk>
-      </activation>
-      <properties>
-        <testng.version>7.9.0</testng.version>
-      </properties>
     </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -325,11 +325,11 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <!-- NB: The same version declaration and configuration block also
              appears in the <reporting> section, and must be kept in sync. -->
-        <version>3.10.0</version>
+        <version>3.12.0</version>
         <configuration>
           <failOnError>true</failOnError>
           <links>
-            <link>http://docs.oracle.com/javase/11/docs/api/</link>
+            <link>https://docs.oracle.com/en/java/javase/11/docs/api/</link>
           </links>
         </configuration>
         <executions>


### PR DESCRIPTION
See https://www.openmicroscopy.org/2026/03/24/end-of-java-8-support.html. Similar to https://github.com/ome/ome-metakit/pull/33.