### PR TITLE
Bump ch.qos.logback:logback-classic from 1.3.16 to 1.5.34

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>2.0.9</version>
+      <version>2.0.18</version>
     </dependency>
 
     <!-- NB: dependency:analyze has false warning about xml-apis:xml-apis. -->

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.3.16</version>
+      <version>1.5.34</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<configuration>
+<configuration scan="true">
   <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%d [%t] %-5p %c - %m%n</pattern>


### PR DESCRIPTION
With the increase of the minimal runtime requirement to Java 11, it should be safe to move to the active 1.5.x series of logback - https://logback.qos.ch/news.html